### PR TITLE
Add syntax highlighting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ history.listen(location => {
   currentPath = location.pathname;
 });
 
+import 'highlight.js/styles/github.css'
 import './App.scss';
 
 class App extends React.Component {

--- a/src/containers/OAuth.tsx
+++ b/src/containers/OAuth.tsx
@@ -3,6 +3,7 @@ import { HashLink as Link } from 'react-router-hash-link';
 
 import Oauth from '../content/apiDocs/oauthTechnical.mdx';
 
+import 'highlight.js/styles/github.css'
 import './OAuth.scss';
 
 class OAuth extends React.Component {

--- a/src/containers/OAuth.tsx
+++ b/src/containers/OAuth.tsx
@@ -3,7 +3,6 @@ import { HashLink as Link } from 'react-router-hash-link';
 
 import Oauth from '../content/apiDocs/oauthTechnical.mdx';
 
-import 'highlight.js/styles/github.css'
 import './OAuth.scss';
 
 class OAuth extends React.Component {

--- a/src/content/apiDocs/oauthTechnical.mdx
+++ b/src/content/apiDocs/oauthTechnical.mdx
@@ -35,9 +35,7 @@ Initiate the OpenID Connect authorization by directing Veterans using your appli
 
 Example Authorization URL:
 
-```
-https://deptva-eval.okta.com/oauth2/default/v1/authorize?client_id=0oa1c01m77heEXUZt2p7&redirect_uri=http://localhost:8080/implicit/callback&response_type=id_token token&response_mode=fragment&state=1AOQK33KIfH2g0ADHvU1oWAb7xQY7p6qWnUFiG1ffcUdrbCY1DBAZ3NffrjaoBGQ&nonce=o5jYpLSe29RBHBsn5iAnMKYpYw2Iw9XRBweacc001hRo5xxJEbHuniEbhuxHfVZy&scope=openid profile email veteran_status.read
-```
+<pre><code>https://deptva-eval.okta.com/oauth2/default/v1/authorize?client_id=0oa1c01m77heEXUZt2p7&redirect_uri=http://localhost:8080/implicit/callback&response_type=id_token token&response_mode=fragment&state=1AOQK33KIfH2g0ADHvU1oWAb7xQY7p6qWnUFiG1ffcUdrbCY1DBAZ3NffrjaoBGQ&nonce=o5jYpLSe29RBHBsn5iAnMKYpYw2Iw9XRBweacc001hRo5xxJEbHuniEbhuxHfVZy&scope=openid profile email veteran_status.read</code></pre>
 
 The Veteran will be taken through a flow where they are authenticated by VA.gov and then asked to consent to allowing your application access to the data it is requesting (as defined by your scopes). After authorizing, your application will receive slightly different responses based on the `response_type` you requested.
 
@@ -48,9 +46,9 @@ This flow works for applications that aren't able to keep a *client secret* prot
 The Veteran authorizing your application will be redirected to your application's `redirect_uri` and will receive tokens in the URL's query or fragment depending on the value of `response_mode` (default is fragment). If you requested an `id_token` it will be returned as a parameter called `id_token`. If you requested a `token`, it will be returned as a parameter called `access_token`.
 
 The Veteran's client will receive
-```
+```http
 HTTP/1.1 302 Found
-Location: {your redirect uri}#
+Location: http://example.com?
   scope=openid%20profile%20email
   &id_token=asdjkfa...
   &state=af0ifjsldkj
@@ -59,7 +57,7 @@ Location: {your redirect uri}#
 
 and your application will then receive
 
-```
+```http
 GET {your redirect uri path}#
   scope=openid%20profile%20email
   &id_token=asdjkfa...
@@ -77,7 +75,7 @@ This flow is used by applications that are able to safely store a *client secret
 The Veteran authorizing your application will be redirect to your application's `redirect_uri` and will receive a `code` parameter either in the URL's query or fragment depending on the value of `response_mode`, defaulting to fragment.
 
 The Veteran's client will receive
-```
+```http
 HTTP/1.1 302 Found
 Location: {your redirect uri}#
   response_type=code
@@ -89,7 +87,7 @@ Location: {your redirect uri}#
 
 and your application will then receive
 
-```
+```http
 GET {your redirect uri path}#
   response_type=code
   &scope=openid%20profile%20email
@@ -101,7 +99,7 @@ Host: {your redirect uri host}
 
 Your application then makes a request to the token endpoint at `https://deptva-eval.okta.com/oauth2/default/v1/token` using the returned code and your *client id* and *client secret* as HTTP Basic authorization. Your token request should look like:
 
-```
+```http
 POST /oauth2/default/v1/token HTTP/1.1
 Host: deptva-eval.okta.com
 Content-Type: application/x-www-form-urlencoded
@@ -112,7 +110,7 @@ grant_type=authorization_code&code={your code}&redirect_uri={your redirect_uri}
 
 The token server will respond with:
 
-```
+```json
 HTTP/1.1 200 OK
 Content-Type: application/json
 Cache-Control: no-store
@@ -128,7 +126,7 @@ Pragma: no-cache
 
 or if an error occurs:
 
-```
+```http
 HTTP/1.1 400 Bad Request
 Content-Type: application/json
 Cache-Control: no-store
@@ -143,7 +141,7 @@ The resulting `access_token` can used to authorize requests to the VA API Platfo
 
 The `refresh_token` can be used to obtain a new `access_token` after its expiry by sending the following request
 
-```
+```http
 POST /oauth2/default/v1/token HTTP/1.1
 Host: deptva-eval.okta.com
 Content-Type: application/x-www-form-urlencoded
@@ -160,7 +158,7 @@ By specifying more than one value in the `response_type` when initiating your au
 
 If you request `response=code id_token`, the Veteran's client will be issued a redirect like
 
-```
+```http
 HTTP/1.1 302 Found
 Location: {your redirect uri}#
   response_type=code
@@ -174,7 +172,7 @@ Location: {your redirect uri}#
 
 and your application will receive
 
-```
+```http
 GET {your redirect uri path}#
   response_type=code
   &scope=openid%20profile%20email

--- a/src/content/apiDocs/oauthTechnical.mdx
+++ b/src/content/apiDocs/oauthTechnical.mdx
@@ -34,8 +34,9 @@ Initiate the OpenID Connect authorization by directing Veterans using your appli
 * `state` - optional - Ensures authorization flow integrity. See [security](#security-considerations).
 
 Example Authorization URL:
-
-<pre><code>https://deptva-eval.okta.com/oauth2/default/v1/authorize?client_id=0oa1c01m77heEXUZt2p7&redirect_uri=http://localhost:8080/implicit/callback&response_type=id_token token&response_mode=fragment&state=1AOQK33KIfH2g0ADHvU1oWAb7xQY7p6qWnUFiG1ffcUdrbCY1DBAZ3NffrjaoBGQ&nonce=o5jYpLSe29RBHBsn5iAnMKYpYw2Iw9XRBweacc001hRo5xxJEbHuniEbhuxHfVZy&scope=openid profile email veteran_status.read</code></pre>
+```plaintext
+https://deptva-eval.okta.com/oauth2/default/v1/authorize?client_id=0oa1c01m77heEXUZt2p7&redirect_uri=http://localhost:8080/implicit/callback&response_type=id_token token&response_mode=fragment&state=1AOQK33KIfH2g0ADHvU1oWAb7xQY7p6qWnUFiG1ffcUdrbCY1DBAZ3NffrjaoBGQ&nonce=o5jYpLSe29RBHBsn5iAnMKYpYw2Iw9XRBweacc001hRo5xxJEbHuniEbhuxHfVZy&scope=openid profile email veteran_status.read
+```
 
 The Veteran will be taken through a flow where they are authenticated by VA.gov and then asked to consent to allowing your application access to the data it is requesting (as defined by your scopes). After authorizing, your application will receive slightly different responses based on the `response_type` you requested.
 
@@ -99,7 +100,7 @@ Host: {your redirect uri host}
 
 Your application then makes a request to the token endpoint at `https://deptva-eval.okta.com/oauth2/default/v1/token` using the returned code and your *client id* and *client secret* as HTTP Basic authorization. Your token request should look like:
 
-```http
+```plaintext
 POST /oauth2/default/v1/token HTTP/1.1
 Host: deptva-eval.okta.com
 Content-Type: application/x-www-form-urlencoded
@@ -110,7 +111,7 @@ grant_type=authorization_code&code={your code}&redirect_uri={your redirect_uri}
 
 The token server will respond with:
 
-```json
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 Cache-Control: no-store
@@ -141,7 +142,7 @@ The resulting `access_token` can used to authorize requests to the VA API Platfo
 
 The `refresh_token` can be used to obtain a new `access_token` after its expiry by sending the following request
 
-```http
+```plaintext
 POST /oauth2/default/v1/token HTTP/1.1
 Host: deptva-eval.okta.com
 Content-Type: application/x-www-form-urlencoded


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/717

It turns out our new markdown loader [already includes highlight.js](https://github.com/ticky/markdown-component-loader/blob/v1.1.0/src/convert.js#L104-L134) and it's not configurable, which isn't great. If this becomes on issue, it looks like the maintainer would be open to a PR to change that.

The highlighter kind of mangled some of our HTTP request blocks, so I disabled highlighting of those with the `plaintext` language.

Here's one of the bad highlights that I disabled:
![screen shot 2018-12-17 at 6 31 07 pm](https://user-images.githubusercontent.com/473542/50125025-b4fff280-022c-11e9-8fdc-a338c2b6fedc.png)

And here's an example of it working nicely:
![screen shot 2018-12-17 at 6 51 31 pm](https://user-images.githubusercontent.com/473542/50125047-cfd26700-022c-11e9-8b9f-3ce9fa286b54.png)
