### PR TITLE
Enable Workbox to skipWaiting when a new service worker is available

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -386,6 +386,7 @@ module.exports = (envName) => {
     // the HTML & assets that are part of the Webpack build.
     new WorkboxWebpackPlugin.GenerateSW({
       clientsClaim: true,
+      skipWaiting: true,
       exclude: [/\.map$/, /asset-manifest\.json$/],
       importWorkboxFrom: 'cdn',
       navigateFallback: publicUrl + '/index.html',


### PR DESCRIPTION
We're using Google's workbox to manage the service worker cache for the
developer site. It can be configured to 'skipWaiting' when a new service worker
is available and have that worker immediately take over a site when its ready
instead of waiting for all open versions of the site to be closed then
replacing the service worker, which can mean users see an outdated version of
the site.

Using skipWaiting can mean the site can load initially with and outdated version
of the site JS and then have that JS replaced when the new Service Worker loads,
which can potentially cause site inconsistencies. Since we're largely just using
this page for static content at the moment, this doesn't seem like a big risk
for the tradeoff of always serving an up-to-date version, and we can re-evaluate
later when we're closer to adding full self-service features.

Resolves department-of-veterans-affairs/vets-contrib#710