### PR TITLE
Change page even if a token is not returned

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6389,7 +6389,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6754,7 +6755,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6802,6 +6804,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6840,11 +6843,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -158,7 +158,7 @@ export const submitForm : ActionCreator<SubmitFormThunk> = () => {
       })
       .then((response) => response.json())
       .then((json) => {
-        if (json.token) {
+        if (json.token || json.clientID) {
           const result = dispatch(submitFormSuccess(
             json.token,
             json.clientID,


### PR DESCRIPTION
It's possible to have a response without a token (ie if you're only requesting health). this change handles that. 