### PR TITLE
More lenient linting during development.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "predeploy": "npm run-script build",
     "deploy": "gh-pages -d build",
     "lint": "./node_modules/.bin/tslint --config tslint.json --project tsconfig.json",
-    "lint:ci": "./node_modules/.bin/tslint --config tslint.json --project tsconfig.json -t junit > lint-results.xml",
+    "lint:ci": "./node_modules/.bin/tslint --config tslint.ci.json --project tsconfig.json -t junit > lint-results.xml",
     "test": "echo You should run test:unit, test:e2e, test:accessibility, or test:visual",
     "test:unit": "node scripts/test.js --projects=unit.jest.config.js",
     "test:unit:ci": "node scripts/test.js --projects=unit.jest.config.js --ci --testResultsProcessor=\"./node_modules/jest-junit-reporter\"",

--- a/tslint.ci.json
+++ b/tslint.ci.json
@@ -1,0 +1,15 @@
+{
+  "extends": ["./tslint.json"],
+  "rules": {
+    "no-unused-variable": {
+      "severity": "error"
+    },
+    "no-console": {
+      "severity": "error"
+    },
+    "prefer-const": {
+      "severity": "error"
+    }
+  }
+}
+

--- a/tslint.json
+++ b/tslint.json
@@ -17,11 +17,14 @@
       },
       "severity": "error"
     },
+    "no-unused-variable": {
+      "severity": "off"
+    },
     "no-console": {
-      "severity": "error"
+      "severity": "off"
     },
     "prefer-const": {
-      "severity": "error"
+      "severity": "off"
     },
     "react-a11y-anchors": {
       "severity": "warning"


### PR DESCRIPTION
I've split the default tslint config and the config we run during CI tests in order to avoid developers having to change rules while developing. This opens up the possibility of pushing a PR for a set of changes that will fail the linter during CI but not locally. To me that seems annoying but less annoying than the status quo.  The `no-unused-variable` and `prefer-const` rules are very noisy in development if you comment out something temporarily. Both of these issues usually crop up during debugging when you comment out the only call of a function or the only time a variable is reassigned. The `no-console` rule should be obvious :)