### PR TITLE
Prevent archive stage from running on PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,6 +248,10 @@ node('vetsgov-general-purpose') {
     if (supercededByConcurrentBuild()) { return }
     if (!onDeployableBranch()) { return }
 
+    // This could only happen in the rare case that a PR is opened from master -> another branch,
+    // which is unlikely, but potentially disastrous.
+    if (prNum) { return } 
+
     try {
       withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload',
                         usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {


### PR DESCRIPTION
I believe the root cause of our recent developer.va.gov outage was https://github.com/department-of-veterans-affairs/developer-portal/pull/79. Since the base branch was master, and there was an associated pull request, the webpack build ran with the `PUBLIC_URL` altered for a review deploy _and_ the archive stage ran as well.

This change ensures that those two things can't happen together: 
- either the jenkins job is running on a PR branch and the webpack build will use our review bucket for the PUBLIC_URL or
- the jenkins job is running on the master branch and the archive stage will run
