### PR TITLE
Updates the Support link to vets-api-clients New Issue page

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -110,7 +110,7 @@ export class NavBar extends React.Component<INavBarProps, INavBarState> {
                 {this.state.visibleSubNavs.documentation && this.renderDocumentationSubNav()}
               </li>
               <li className="main-nav-item">
-                <a href="mailto:api@va.gov" className="usa-nav-link"
+                <a href="https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose" className="usa-nav-link"
                   onMouseEnter={this.toggleDefaultNavLink.bind(this, false)}
                   onMouseLeave={this.toggleDefaultNavLink.bind(this, true)}>
                   Support

--- a/src/containers/ApplyForm.tsx
+++ b/src/containers/ApplyForm.tsx
@@ -210,7 +210,7 @@ class ApplyForm extends React.Component<IApplyProps> {
 
   private renderError() {
     const assistanceTrailer = (
-      <span>Need assistance? Email us at <a href="mailto:api@va.gov">api@va.gov</a></span>
+      <span>Need assistance? Create an issue on our <a href="https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose">Github page</a></span>
     );
 
     if (this.props.errorStatus) {


### PR DESCRIPTION
This PR updates the Support link in the main nav and the /apply page error message to point to https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose instead of `mailto: api@va.gov`. It's creation was based on [this Slack thread](https://lighthouseva.slack.com/archives/CAZF880HW/p1552927119006700).

This would only be short term until a Support page is created as a follow-up step.