### PR TITLE
Update disclaimer banner

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import { VeteransCrisisLine } from './VeteransCrisisLine';
 
 import './Banner.scss';
@@ -19,27 +18,24 @@ export class Banner extends React.Component<{}, IBannerState> {
 
   constructor(props: {}) {
       super(props);
-      this.state = { 
+      this.state = {
         accordionVisible: false,
         menuVisible: false,
       };
   }
 
   public render() {
-    const dotGovGuidanceText = `Federal government websites often end in .gov or .mil. Before sharing sensitive 
+    const dotGovGuidanceText = `Federal government websites often end in .gov or .mil. Before sharing sensitive
                                 information, make sure you're on a federal government site.`;
     const httpsGuidanceText = (
       <span>
-        The <strong>https://</strong> ensures that you're connecting to the official website 
+        The <strong>https://</strong> ensures that you're connecting to the official website
         and that any information you provide is encrypted and sent securely.
       </span>
     );
 
     return (
       <section className="usa-banner site-banner">
-        <AlertBox status="info"
-              headline={"This site is currently under development."}
-              isVisible={true} />
         <div className="site-guidance usa-accordion">
           <header className="usa-banner-header">
             <div className="usa-grid usa-banner-inner">
@@ -57,9 +53,9 @@ export class Banner extends React.Component<{}, IBannerState> {
               </div>
               <div className="usa-banner-content usa-accordion-content" aria-hidden={this.state.accordionVisible ? "false" : "true"}>
                 {this.renderSiteGuidance(
-                    "banner-guidance-gov", 
-                    dotGovIcon, 
-                    "The .gov means it's official", 
+                    "banner-guidance-gov",
+                    dotGovIcon,
+                    "The .gov means it's official",
                     dotGovGuidanceText)}
                 {this.renderSiteGuidance(
                     "banner-guidance-ssl",
@@ -105,7 +101,7 @@ export class Banner extends React.Component<{}, IBannerState> {
   private renderSiteGuidance(className: string, iconContent: string, titleText: {}, bodyText: {}) {
     return (
       <div className={className}>
-        <img className="usa-banner-icon usa-media_block-img" src={iconContent} 
+        <img className="usa-banner-icon usa-media_block-img" src={iconContent}
               alt="Dot Gov" />
         <div className="guidance-content usa-media_block-body">
           <div className="guidance-title">

--- a/src/components/NavBar.scss
+++ b/src/components/NavBar.scss
@@ -3,7 +3,7 @@
 .usa-header.usa-header-extended {
   background: $color-blue-darkest;
 
-  .usa-logo { 
+  .usa-logo {
     @include media($large-screen) {
       margin-top: 4rem;
     }
@@ -16,15 +16,15 @@
 
   @include media($large-screen) {
     .usa-nav-secondary {
-      top: -8.5rem;
+      top: -7.25rem;
     }
   }
-  
+
   .usa-navbar {
     max-width: none;
 
     @include media($large-screen) {
-      height: 120px;
+      height: 110px;
     }
   }
 
@@ -90,7 +90,7 @@
       }
     }
 
-    li.main-nav-item, 
+    li.main-nav-item,
     li.main-nav-secondary-item {
       margin-bottom: 0;
       padding-top: 8px;

--- a/src/containers/Home.scss
+++ b/src/containers/Home.scss
@@ -1,6 +1,12 @@
 @import '../base';
 
 .Home {
+   .site-disclaimer {
+     background-color: $color-gold;
+     padding-top: 16px;
+     padding-bottom: 16px;
+     padding-left: 20px;
+   }
     .usa-hero {
         background-color: #4a4a4a;
         background-image: url('../assets/home-page-banner.png');

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -9,6 +9,11 @@ class Home extends React.Component {
     public render() {
         return (
             <div className="Home">
+              <div className="site-disclaimer">
+                <strong>This is beta site.</strong> We are always looking to make improvements. <a href="https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose">
+                  <strong>Send us your feedback</strong>
+                </a>
+              </div>
               <PageHero
                   title="Put VA Data to Work"
                   content="Empowering our partners to build innovative, Veteran-centered solutions."

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -10,7 +10,7 @@ class Home extends React.Component {
         return (
             <div className="Home">
               <div className="site-disclaimer">
-                <strong>This is beta site.</strong> We are always looking to make improvements. <a href="https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose">
+                <strong>This is a beta site.</strong> We are always looking to make improvements. <a href="https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose">
                   <strong>Send us your feedback</strong>
                 </a>
               </div>


### PR DESCRIPTION
This PR updates the disclaimer banner to:

- Only be on the homepage
- Update design to be in sync with new UI
- Add feedback link to GitHub issue templates on [vets-api-clients](https://github.com/department-of-veterans-affairs/vets-api-clients)
- Small fix to header spacing

See screencast below to see updated design + link to feedback form.


<img width="1203" alt="Screen Shot 2019-03-21 at 9 44 57 AM" src="https://user-images.githubusercontent.com/955558/54756173-07e79e00-4bbe-11e9-920f-5d4dedb196d2.png">


