### PR TITLE
fixes all terms-of-service links that were still pointing through /explore

### DIFF
--- a/SitemapBuilderWebpackPlugin.js
+++ b/SitemapBuilderWebpackPlugin.js
@@ -114,7 +114,7 @@ class SitemapBuilderPlugin {
 
     const pathFilter = {
       isValid: false,
-      rules: [/index.html|\/terms-of-service|\/applied|\/beta-success/],
+      rules: [/index.html|\/explore\/terms-of-service|\/applied|\/beta-success/],
     };
 
     const paramsConfig = {

--- a/SitemapBuilderWebpackPlugin.js
+++ b/SitemapBuilderWebpackPlugin.js
@@ -114,7 +114,7 @@ class SitemapBuilderPlugin {
 
     const pathFilter = {
       isValid: false,
-      rules: [/index.html|\/explore\/terms-of-service|\/applied|\/beta-success/],
+      rules: [/index.html|\/terms-of-service|\/applied|\/beta-success/],
     };
 
     const paramsConfig = {

--- a/src/containers/ApplyForm.tsx
+++ b/src/containers/ApplyForm.tsx
@@ -164,7 +164,7 @@ class ApplyForm extends React.Component<IApplyProps> {
                 checked={termsOfService}
                 label={(
                     <span>
-                      I agree to the <Link target="_blank" to="/explore/terms-of-service">Terms of Service</Link>
+                      I agree to the <Link target="_blank" to="/terms-of-service">Terms of Service</Link>
                     </span>
                 )}
                 onValueChange={props.toggleAcceptTos}

--- a/src/content/apiDocs/benefitsOverview.mdx
+++ b/src/content/apiDocs/benefitsOverview.mdx
@@ -1,6 +1,6 @@
 ## Overview
 
-Our goal is to make easier and more secure for VSOs and other organizations to interact with the VA on behalf of Veterans. When you’re ready for production, review these [Terms of Service](/#/explore/terms-of-service) and then request it [here](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new). Individual API documentation is available above. 
+Our goal is to make easier and more secure for VSOs and other organizations to interact with the VA on behalf of Veterans. When you’re ready for production, review these [Terms of Service](/#/terms-of-service) and then request it [here](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new). Individual API documentation is available above. 
 
 ### Path to Production for Alpha API Clients
 
@@ -37,7 +37,7 @@ First, you must provide some basic information including:
 Next, the following criteria needs to be met and verified by the API team.
 
 * You are a US based company
-* You agree to the [Terms of Service](/#/explore/terms-of-service)
+* You agree to the [Terms of Service](/#/terms-of-service)
 * The VA team is able to verify your information
 * The VA team views a live demo of your application using the API in a test environment and approves of the use case and need for API access
 

--- a/src/content/apiDocs/benefitsOverview.mdx
+++ b/src/content/apiDocs/benefitsOverview.mdx
@@ -1,6 +1,6 @@
 ## Overview
 
-Our goal is to make easier and more secure for VSOs and other organizations to interact with the VA on behalf of Veterans. When you’re ready for production, review these [Terms of Service](/#/terms-of-service) and then request it [here](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new). Individual API documentation is available above. 
+Our goal is to make easier and more secure for VSOs and other organizations to interact with the VA on behalf of Veterans. When you’re ready for production, review these [Terms of Service](/terms-of-service) and then request it [here](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new). Individual API documentation is available above. 
 
 ### Path to Production for Alpha API Clients
 
@@ -37,7 +37,7 @@ First, you must provide some basic information including:
 Next, the following criteria needs to be met and verified by the API team.
 
 * You are a US based company
-* You agree to the [Terms of Service](/#/terms-of-service)
+* You agree to the [Terms of Service](/terms-of-service)
 * The VA team is able to verify your information
 * The VA team views a live demo of your application using the API in a test environment and approves of the use case and need for API access
 


### PR DESCRIPTION
This PR fixes all legacy `/explore/terms-of-service` links and changes them to `/terms-of-service`.

There is still code that was supposed to auto-redirect, but it wasn't working in `Routes.tsx` (`<Route path="/explore/terms-of-service" render={props1 => <Redirect to="/terms-of-service" />} />`) but I left that alone for now in case it should be fixed instead of deleted.