### PR TITLE
Wrap routes in switch

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { RouteComponentProps } from 'react-router';
+import { RouteComponentProps, Switch } from 'react-router';
 import { Redirect, Route } from 'react-router-dom';
 
 import { apiCategoryOrder, apiDefs } from './apiDefs';
@@ -10,22 +10,24 @@ import { ApplyForm, ApplySuccess, BetaPage, BetaSuccess, ExploreDocs, Home, OAut
 export function topLevelRoutes(props: RouteComponentProps<void>) {
     return (
       <PageContent {...props} >
-        <Route exact={true} path="/" component={Home} />
-        <Route exact={true} path="/index.html" component={Home} />
+        <Switch>
+          <Route exact={true} path="/" component={Home} />
+          <Route exact={true} path="/index.html" component={Home} />
 
-        {/* Legacy routes that we want to maintain: */}
-        <Route path="/explore/terms-of-service" render={() => <Redirect to="/terms-of-service" />} />
+          {/* Legacy routes that we want to maintain: */}
+          <Route path="/explore/terms-of-service" render={() => <Redirect to="/terms-of-service" />} />
 
-        {/* Current routes: */}
-        <Route path="/go-live" component={RoutedContent} />
-        <Route path="/terms-of-service" component={RoutedContent} />
-        <Route path="/apply" component={ApplyForm} />
-        <Route path="/applied" component={ApplySuccess} />
-        <Route path="/beta" component={BetaPage} />
-        <Route path="/beta-success" component={BetaSuccess} />
-        <Route path="/explore/:apiCategoryKey?" component={ExploreDocs} />
-        <Route exact={true} path="/explore/:apiCategoryKey/docs/:apiName" />
-        <Route path="/oauth" component={OAuth} />
+          {/* Current routes: */}
+          <Route path="/go-live" component={RoutedContent} />
+          <Route path="/terms-of-service" component={RoutedContent} />
+          <Route path="/apply" component={ApplyForm} />
+          <Route path="/applied" component={ApplySuccess} />
+          <Route path="/beta" component={BetaPage} />
+          <Route path="/beta-success" component={BetaSuccess} />
+          <Route path="/explore/:apiCategoryKey?" component={ExploreDocs} />
+          <Route exact={true} path="/explore/:apiCategoryKey/docs/:apiName" />
+          <Route path="/oauth" component={OAuth} />
+        </Switch>
       </PageContent>
     );
   }

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -14,7 +14,7 @@ export function topLevelRoutes(props: RouteComponentProps<void>) {
         <Route exact={true} path="/index.html" component={Home} />
 
         {/* Legacy routes that we want to maintain: */}
-        <Route path="/explore/terms-of-service" render={props1 => <Redirect to="/terms-of-service" />} />
+        <Route path="/explore/terms-of-service" render={() => <Redirect to="/terms-of-service" />} />
 
         {/* Current routes: */}
         <Route path="/go-live" component={RoutedContent} />

--- a/src/components/PageContent.tsx
+++ b/src/components/PageContent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { RouteComponentProps } from 'react-router'
+import { RouteComponentProps, Switch } from 'react-router'
 
 interface IPageContentProps extends RouteComponentProps<void> {
     children: JSX.Element[];
@@ -23,7 +23,9 @@ export class PageContent extends React.Component<IPageContentProps, {}> {
         return (
             <div className="PageContent">
               <div className="content-main" ref={(loader) => (this.loader = loader)} tabIndex={-1}>
-                {this.props.children}
+                <Switch>
+                  {this.props.children}
+                </Switch>
               </div>
             </div>
         );

--- a/src/components/PageContent.tsx
+++ b/src/components/PageContent.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-import { RouteComponentProps, Switch } from 'react-router'
+import { RouteComponentProps } from 'react-router'
 
 interface IPageContentProps extends RouteComponentProps<void> {
-    children: JSX.Element[];
+    children: JSX.Element[] | JSX.Element;
 }
 
 export class PageContent extends React.Component<IPageContentProps, {}> {
@@ -23,9 +23,7 @@ export class PageContent extends React.Component<IPageContentProps, {}> {
         return (
             <div className="PageContent">
               <div className="content-main" ref={(loader) => (this.loader = loader)} tabIndex={-1}>
-                <Switch>
-                  {this.props.children}
-                </Switch>
+                {this.props.children}
               </div>
             </div>
         );


### PR DESCRIPTION
Turns out the router renders all the matching routes, not just the first or most specific one, if you don't have `<Switch>` around them.