### PR TITLE
Fix for /applied page from bug introduced in #113

### DIFF
--- a/src/containers/ApplySuccess.tsx
+++ b/src/containers/ApplySuccess.tsx
@@ -93,7 +93,9 @@ function ApplySuccess(props: IApplication) {
                     ? null
                     : <ApiKeyNotice email={email} token={token} selectedApis={selectedApiNames(apis)} />;
 
-  const oAuthNotice = <OAuthCredentialsNotice email={email} clientID={clientID} clientSecret={clientSecret} selectedApis={selectedApiNames(apis)} />;
+  const oAuthNotice = ((apis.health || apis.verification) && clientID && clientSecret)
+                    ? <OAuthCredentialsNotice email={email} clientID={clientID} clientSecret={clientSecret} selectedApis={selectedApiNames(apis)} />
+                    : null;
 
   return (
     <div role="region" aria-labelledby="apply-region" className="usa-grid api-application">


### PR DESCRIPTION
Merging https://github.com/department-of-veterans-affairs/developer-portal/pull/113 introduced a bug where the `/applied` page always displayed fields for `Your VA API OAuth Client ID` and `Your VA API OAuth Client Secret` even if no OAuth APIs were selected. This PR fixes this.