### PR TITLE
Update node sample app path in authorization documentation

### DIFF
--- a/src/content/apiDocs/oauthTechnical.mdx
+++ b/src/content/apiDocs/oauthTechnical.mdx
@@ -123,7 +123,7 @@ Pragma: no-cache
 
 {
   "access_token": "SlAV32hkKG",
-  "expires_at": 1553270937
+  "expires_at": 1553270937,
   "refresh_token": "8xLOxBtZp8",
   "scope": "openid profile email offline_access",
   "state": "af0ifjsldkj",

--- a/src/content/apiDocs/oauthTechnical.mdx
+++ b/src/content/apiDocs/oauthTechnical.mdx
@@ -257,7 +257,7 @@ If you have any questions please feel free to reach out to the VA API Platform t
 
 ## Sample Application
 
-We provide a sample [Node.JS](https://nodejs.org/en/) application for demonstrating how to get up and running with our OAuth system. You can find the complete source code for it on our [GitHub](https://github.com/department-of-veterans-affairs/vets-api-clients/tree/master/oauth/node). The following walk-through will show step-by-step how to setup a Node.JS application to use VA OAuth using [express](https://expressjs.com/), [passport](http://www.passportjs.org/), and [node-openid-client](https://github.com/panva/node-openid-client). 
+We provide a sample [Node.JS](https://nodejs.org/en/) application for demonstrating how to get up and running with our OAuth system. You can find the complete source code for it on our [GitHub](https://github.com/department-of-veterans-affairs/vets-api-clients/tree/master/samples/oauth_node). The following walk-through will show step-by-step how to setup a Node.JS application to use VA OAuth using [express](https://expressjs.com/), [passport](http://www.passportjs.org/), and [node-openid-client](https://github.com/panva/node-openid-client). 
 
 ### Requirements
 


### PR DESCRIPTION
Updates link to the node sample app in our authorization documentation to coincide with department-of-veterans-affairs/vets-api-clients/pull/63. Also adds a missing comma that was causing to weird coloring in a code block.