### PR TITLE
Argonaut swagger pointed to prod instead of staging

### DIFF
--- a/src/apiDefs.ts
+++ b/src/apiDefs.ts
@@ -115,7 +115,7 @@ export const apiDefs: IApiCategories = {
     apis: [
       {
         name: 'Veterans Health API',
-        openApiDocUrl: 'https://staging-api.va.gov/services/argonaut/v0/openapi.json',
+        openApiDocUrl: 'https://api.va.gov/services/argonaut/v0/openapi.json',
         shortDescription: "VA's Argonaut resources",
         urlFragment: 'argonaut',
         vaInternalOnly: false,


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/2444

It is confusing looking at the production developer portal and seeing a swagger doc hosted in 'staging'. It is not an option to grab the document from the current environment. The health API swagger doc is not available in dev. The health API is going to be going through changes in the near future, changing from being hosted at /argonaut to /fhir, so spending a lot of time on this now seems wasteful. Simplest solution is to update the hardcoded health api swagger spec to point to production instead of staging. This allows the spec to still be pulled down in all three environments, with the production development portal showing that the document is from production, which is what users expect.