### PR TITLE
Add Community Care Eligibility OpenAPI spec - #2057

### DIFF
--- a/src/apiDefs/health.ts
+++ b/src/apiDefs/health.ts
@@ -17,7 +17,7 @@ const healthApis : IApiDescription[] = [
     docSources: [
       {
         apiIntro: CommunityCareApiIntro,
-        openApiUrl: '',
+        openApiUrl: 'https://dev-api.va.gov/services/community-care/v0/eligibility/openapi.json',
       },
     ],
     name: 'Community Care Eligibility API',


### PR DESCRIPTION
Adds the OpenAPI JSON for Community Care to complete [vets-contrib #2057](https://github.com/department-of-veterans-affairs/vets-contrib/issues/2057).