### PR TITLE
Selected tab shown in fragment

### DIFF
--- a/src/containers/Explore.tsx
+++ b/src/containers/Explore.tsx
@@ -30,7 +30,7 @@ const mapStateToProps = ({ routing }: IRootState) => {
 
 class Explore extends React.Component<IExploreProps, IExploreState> {
   public static getDerivedStateFromProps(props: any, state: any) {
-    const api = lookupApiByFragment(props.match.params.apiName)
+    const api = lookupApiByFragment(props.match.params.apiName);
 
     if (api) {
       const docSources = api.docSources;
@@ -41,7 +41,7 @@ class Explore extends React.Component<IExploreProps, IExploreState> {
       }
 
     }
-    return {}
+    return {};
   }
 
   private static getTabIndexFromFragment(api: IApiDescription, props: RouteComponentProps<IApiNameParam>) : number {


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/2424

This PR makes the selected tab show up in the fragment of the URL. When visiting a tabbed API the first tab in the list is used as the fragment. Selecting tabs no longer changes the component state but will update the fragment, causing a rerender. The tab to show is selected based on the url fragment. The basic flow is:

 1) User selects a new tab (or loads the API documentation page)
 2) The URL fragment is updated, causing a re-render
 3) `getDerivedStateFromProps` sees the new URL fragment, setting the tab state accordingly
 4) The component is rendered again with the new tab state

Let me know if there is a better way to accomplish having the selected tab show up in the fragment of the url. I believe I am using the react life-cycle methods correctly. Rendering twice for the tab change may be a big deal or not. I don't have enough React experience to know if there is a better way.