### PR TITLE
Fix link to node sample app

### DIFF
--- a/src/content/apiDocs/oauthTechnical.mdx
+++ b/src/content/apiDocs/oauthTechnical.mdx
@@ -480,4 +480,4 @@ Now, after restarting `node index.js` you can first navigate to `<yourRedirectHo
 
 ### Get all the code
 
-Find the full code for the sample app [here](https://github.com/department-of-veterans-affairs/vets-api-clients/blob/master/test_accounts.md).
+Find the full code for the sample app [here](https://github.com/department-of-veterans-affairs/vets-api-clients/tree/master/samples/oauth_node).


### PR DESCRIPTION
Updated the link at the bottom of the OAuth authentication documentation to point to the node sample app instead of the test user accounts.