### PR TITLE
Set url prefix when uploading source maps

### DIFF
--- a/scripts/upload_source_map.sh
+++ b/scripts/upload_source_map.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 sentry-cli releases new $SENTRY_RELEASE
-sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps $SOURCE_DIR
+sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps $SOURCE_DIR --url-prefix '~/static/js'
 sentry-cli releases finalize $SENTRY_RELEASE


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/1762

Sentry needs the path to the source map file, https://docs.sentry.io/platforms/javascript/sourcemaps/#verify-artifact-names-match-sourcemappingurl-value.