### PR TITLE
Remove underline/italics from logo

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -53,11 +53,9 @@ export default class NavBar extends React.Component<INavBarProps, INavBarState> 
         <Banner />
         <div className="header-content">
           <div className="usa-logo" id="extended-logo">
-            <em className="usa-logo-text">
-              <Link to="/" title="Digital VA home page">
-                <strong>VA</strong> | Developer Portal
-              </Link>
-            </em>
+            <Link to="/" title="Digital VA home page" className="vads-u-text-decoration--none">
+              <strong>VA</strong> | Developer Portal
+            </Link>
           </div>
           <div className="header-right-container">
             <MediaQuery query={OVER_LARGE_SCREEN_QUERY}>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -54,7 +54,7 @@ export default class NavBar extends React.Component<INavBarProps, INavBarState> 
         <div className="header-content">
           <div className="usa-logo" id="extended-logo">
             <Link to="/" title="Digital VA home page" className="vads-u-text-decoration--none">
-              <strong>VA</strong> | Developer Portal
+              <span className="vads-u-font-weight--bold">VA</span> | Developer Portal
             </Link>
           </div>
           <div className="header-right-container">


### PR DESCRIPTION
Got rid of an `em` (not sure why it was there) and a `strong` that was just being used to make something bold.