### PR TITLE
Use variables from VADS instead of defining our own

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { topLevelRoutes } from './Routes';
 import { history } from './store';
 
 import 'highlight.js/styles/github.css';
-import './base.scss';
+import './styles/base.scss';
 
 class App extends React.Component {
   public render() {

--- a/src/components/Footer.scss
+++ b/src/components/Footer.scss
@@ -5,7 +5,7 @@
 }
 
 .va-api-beta-banner {
-  background-color: $color-blue-dark;
+  background-color: $va-api-color-blue-dark;
 }
 
 .va-api-footer-link-list {

--- a/src/components/Search.scss
+++ b/src/components/Search.scss
@@ -20,10 +20,10 @@
 }
 
 .va-api-search-form--inverse-color {
-  @include va-api-input-text-color($color-off-white);
+  @include va-api-input-text-color($color-gray-lightest);
 
   input.va-api-search-autocomplete {
-    background-color: $color-dark-blue;
+    background-color: $va-api-color-blue-dark;
   }
 }
 
@@ -31,7 +31,7 @@
   button[type=submit] {
     appearance: none;
     background-color: transparent;
-    color: $color-alt-gray;
+    color: $va-api-color-gray-alt;
     overflow: hidden;
 
     &:hover {

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -2,12 +2,12 @@
 // ==========
 
 // Asset reference - must import before VADS
-@import './styles/variables';
+@import './variables';
 
 // Imports
 // =======
 @import '~@department-of-veterans-affairs/formation/sass/full';
-@import './styles/mixins';
+@import './mixins';
 
 // VADS Overrides 🚗
 // ==================

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,17 +1,17 @@
-// Colors
-$color-gray-cool-light: #dce4ef;
-$color-primary-alt-light: #9bdaf1;
-$color-primary-alt-dark: #00a6d2;
-$color-primary-lightest: #e1f3f8;
-$color-primary-darkest: #112e51;
-$color-white: #ffffff;
-$color-base: #212121;
-$color-dark-blue: #12223A;
-$color-gray-lighter: #d6d7d9;
-$color-alt-gray: #C3C8CF;
-$color-gold: #fdb81e;
-$color-red: #cd2026;
-$color-off-white: #F1F1F1;
-$color-primary-alt-lightest: #e1f3f8;
-$color-gray-dark: #323a45;
-$color-blue-dark: #12223A;
+/*
+  This module defines Lighthouse developer portal-specific color variables to supplement the ones 
+  provided by VADS. Please always prefer VADS color definitions over custom ones; see the VADS resources
+  below to check if the color you need is already available or if a similar one can be used instead. 
+  Please also note that all variables in this file are namespaced with the `va-api-` prefix in order to
+  distinguish developer portal vars from VADS ones, and that this convention should be followed for any new
+  variables defined here.
+
+  VADS color resources
+  - Documentation for color utilities, which corresponds pretty directly to the available vars: 
+    https://design.va.gov/utilities/color
+  - Source file for color vars:
+    https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/sass/base/_b-variables.scss
+*/
+
+$va-api-color-blue-dark: #12223a;
+$va-api-color-gray-alt: #c3c8cf;

--- a/src/styles/swagger.scss
+++ b/src/styles/swagger.scss
@@ -106,12 +106,4 @@
       border: none;
     }
   }
-
-  blockquote {
-    line-height: 1.5;
-    color: $color-gray-dark;
-    background: $color-primary-alt-lightest;
-    padding: 1rem;
-    padding-right: 2rem;
-  }
 }

--- a/src/styles/uswdsPatch.scss
+++ b/src/styles/uswdsPatch.scss
@@ -5,16 +5,16 @@
 // * https://github.com/department-of-veterans-affairs/vets-contrib/issues/3012
 
 // Colors
-$color-black: #000000;
-$color-blue-darkest: #112e51;
-$color-gray-light: #aeb0b5;
+// $color-black: #000000;
+// $color-blue-darkest: #112e51;
+// $color-gray-light: #aeb0b5;
 
 // Responsive media
 $small-screen: 481px;
 
 // Fonts
-$helvetica: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
-$font-sans: 'Source Sans Pro', $helvetica;
+// $helvetica: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+// $font-sans: 'Source Sans Pro', $helvetica;
 
 // polyfill media and display-icon mixins
 // see https://github.com/uswds/uswds/blob/v1.6.10/src/stylesheets/core/_utilities.scss

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -15,3 +15,6 @@ $large-screen: 951px;
 // Necessary to include this file to polyfill USWDS resources 
 // to reduce duplication until we can find a compiler-level solution
 @import './uswdsPatch';
+
+// mostly provides $color-* variables but also $font-sans and other typography vars
+@import '~@department-of-veterans-affairs/formation/sass/base/b-variables';


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3011

we have a weird mismatch of variables that we defined ourselves and never really import from the places they're supposed to. this PR is for making VADS the source of truth on those variables.