### PR TITLE
Fix broken VA.gov link.

### DIFF
--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -76,7 +76,7 @@ function VeteransNotice() {
         'vads-u-color--white')}>
         <div className='vads-u-margin-y--2p5'>
           Are you a Veteran looking to submit a claim, manage benefits or access your health data?
-          &nbsp;<Link className={classNames('vads-u-font-weight--bold', 'vads-u-color--white')} to="https://www.va.gov/">Visit VA.gov</Link>
+          &nbsp;<a className={classNames('vads-u-font-weight--bold', 'vads-u-color--white')} href="https://www.va.gov/">Visit VA.gov</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/3444

This switches back to a conventional `<a>` tag [in line with this advice](https://github.com/ReactTraining/react-router/issues/1147#issuecomment-98491574), which seems to be the official recommendation.