### PR TITLE
Make OAuth examples match real URLs.

### DIFF
--- a/src/content/apiDocs/oauthTechnical.mdx
+++ b/src/content/apiDocs/oauthTechnical.mdx
@@ -53,7 +53,7 @@ Your application will need to redirect the user's browser to our OpenID authoriz
 
 ```http
 HTTP/1.1 302 Found
-Location: https://dev-api.va.gov/oauth2/authorize?
+Location: https://dev-api.va.gov/oauth2/authorization?
   client_id=s6BhdRkqt3
   &response_type=id_token
   &response_mode=fragment
@@ -90,7 +90,7 @@ Your application will need to redirect the user's browser to our OpenID authoriz
 
 ```http
 HTTP/1.1 302 Found
-Location: https://dev-api.va.gov/oauth2/authorize?
+Location: https://dev-api.va.gov/oauth2/authorization?
   response_type=code
   &scope=openid%20profile%20email%20offline_access
   &client_id=s6BhdRkqt3


### PR DESCRIPTION
This was a regression introduced by me when I reformatted the authorization docs back in March. The `/authorize` name is what is used in a lot of official OAuth and OIDC specification examples but our auth server uses `/authorization`. You can confirm that by looking at either the oauth-proxy source code or the OIDC metadata endpoint: https://dev-api.va.gov/oauth2/.well-known/openid-configuration