### PR TITLE
Redirect unknown apis to explorer

### DIFF
--- a/src/containers/documentation/DocumentationRoot.e2e.ts
+++ b/src/containers/documentation/DocumentationRoot.e2e.ts
@@ -73,8 +73,10 @@ describe('position sticky', () => {
 });
 
 describe('inavlid cagetories', () => {
-  it('should redirect to explore', async () => {
-    await page.goto(`${puppeteerHost}/explore/invalid`, { waitUntil: 'networkidle0' });
-    expect(page.url()).toEqual(`${puppeteerHost}/explore`);
-  });
+  for (const path of ['', 'docs/quickstart']) {
+    it(`should redirect "explore/invalid/${path}" to "explore"`, async () => {
+      await page.goto(`${puppeteerHost}/explore/invalid/${path}`, { waitUntil: 'networkidle0' });
+      expect(page.url()).toEqual(`${puppeteerHost}/explore`);
+    });
+  }
 });

--- a/src/containers/documentation/DocumentationRoot.e2e.ts
+++ b/src/containers/documentation/DocumentationRoot.e2e.ts
@@ -71,3 +71,10 @@ describe('position sticky', () => {
     expect(haloText).toEqual('Health API');
   });
 });
+
+describe('inavlid cagetories', () => {
+  it('should redirect to explore', async () => {
+    await page.goto(`${puppeteerHost}/explore/invalid`, { waitUntil: 'networkidle0' });
+    expect(page.url()).toEqual(`${puppeteerHost}/explore`);
+  });
+});

--- a/src/containers/documentation/DocumentationRoot.tsx
+++ b/src/containers/documentation/DocumentationRoot.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 import classNames from 'classnames';
 import { Flag } from 'flag';
-import { RouteComponentProps } from 'react-router';
+import { Redirect, RouteComponentProps } from 'react-router';
 import { Route, Switch } from 'react-router-dom';
 
-import { getApiCategoryOrder, getApiDefinitions } from '../../apiDefs/query';
+import { getApiCategoryOrder, getApiDefinitions, lookupApiCategory } from '../../apiDefs/query';
 import { IApiCategory, IApiDescription } from '../../apiDefs/schema';
 import SideNav, { SideNavEntry } from '../../components/SideNav';
 import { IApiNameParam } from '../../types';
@@ -93,30 +93,39 @@ function ExploreSideNav() {
 
 export default class DocumentationRoot extends React.Component<RouteComponentProps<IApiNameParam>, {}> {
   public render() {
+    const { apiCategoryKey } = this.props.match.params;
+    const validCategory = !apiCategoryKey || lookupApiCategory(apiCategoryKey) != null;
     return (
       <div className={classNames('documentation', 'vads-u-padding-y--5')}>
         <section className="vads-l-grid-container">
           <div className="vads-l-row">
             <ExploreSideNav />
             <div className={classNames('vads-l-col--12', 'medium-screen:vads-l-col--8')}>
-              <Route exact={true} path="/explore/" component={DocumentationOverview} />
-              <Route exact={true} path="/explore/:apiCategoryKey" component={CategoryPage} />
               <Switch>
-                <Route
-                  exact={true}
-                  path="/explore/:apiCategoryKey/docs/authorization"
-                  component={AuthorizationDocs}
-                  />
-                <Route
-                  exact={true}
-                  path="/explore/:apiCategoryKey/docs/quickstart"
-                  component={QuickstartPage}
-                  />
-                <Route
-                  exact={true}
-                  path="/explore/:apiCategoryKey/docs/:apiName"
-                  component={ApiPage}
-                  />
+                <Route exact={true} path="/explore/" component={DocumentationOverview} />
+                { validCategory &&
+                  <React.Fragment>
+                    <Route exact={true} path="/explore/:apiCategoryKey" component={CategoryPage} />
+                    <Route
+                      exact={true}
+                      path="/explore/:apiCategoryKey/docs/authorization"
+                      component={AuthorizationDocs}
+                      />
+                    <Route
+                      exact={true}
+                      path="/explore/:apiCategoryKey/docs/quickstart"
+                      component={QuickstartPage}
+                      />
+                    <Route
+                      exact={true}
+                      path="/explore/:apiCategoryKey/docs/:apiName"
+                      component={ApiPage}
+                      />
+                  </React.Fragment>
+                }
+                { !validCategory &&
+                  <Redirect from="/explore/:apiCategoryKey" to="/explore" />
+                }
               </Switch>
             </div>
           </div>

--- a/src/containers/documentation/DocumentationRoot.tsx
+++ b/src/containers/documentation/DocumentationRoot.tsx
@@ -102,29 +102,26 @@ export default class DocumentationRoot extends React.Component<RouteComponentPro
             <ExploreSideNav />
             <div className={classNames('vads-l-col--12', 'medium-screen:vads-l-col--8')}>
               <Switch>
-                <Route exact={true} path="/explore/" component={DocumentationOverview} />
-                { validCategory &&
-                  <React.Fragment>
-                    <Route exact={true} path="/explore/:apiCategoryKey" component={CategoryPage} />
-                    <Route
-                      exact={true}
-                      path="/explore/:apiCategoryKey/docs/authorization"
-                      component={AuthorizationDocs}
-                      />
-                    <Route
-                      exact={true}
-                      path="/explore/:apiCategoryKey/docs/quickstart"
-                      component={QuickstartPage}
-                      />
-                    <Route
-                      exact={true}
-                      path="/explore/:apiCategoryKey/docs/:apiName"
-                      component={ApiPage}
-                      />
-                  </React.Fragment>
-                }
                 { !validCategory &&
                   <Redirect from="/explore/:apiCategoryKey" to="/explore" />
+                }
+                <Route exact={true} path="/explore/" component={DocumentationOverview} />
+                  <Route exact={true} path="/explore/:apiCategoryKey" component={CategoryPage} />
+                  <Route
+                    exact={true}
+                    path="/explore/:apiCategoryKey/docs/authorization"
+                    component={AuthorizationDocs}
+                    />
+                  <Route
+                    exact={true}
+                    path="/explore/:apiCategoryKey/docs/quickstart"
+                    component={QuickstartPage}
+                    />
+                  <Route
+                    exact={true}
+                    path="/explore/:apiCategoryKey/docs/:apiName"
+                    component={ApiPage}
+                    />
                 }
               </Switch>
             </div>

--- a/src/containers/documentation/DocumentationRoot.tsx
+++ b/src/containers/documentation/DocumentationRoot.tsx
@@ -94,7 +94,7 @@ function ExploreSideNav() {
 export default class DocumentationRoot extends React.Component<RouteComponentProps<IApiNameParam>, {}> {
   public render() {
     const { apiCategoryKey } = this.props.match.params;
-    const validCategory = !apiCategoryKey || lookupApiCategory(apiCategoryKey) != null;
+    const shouldRouteCategory = !apiCategoryKey || lookupApiCategory(apiCategoryKey) != null;
     return (
       <div className={classNames('documentation', 'vads-u-padding-y--5')}>
         <section className="vads-l-grid-container">
@@ -102,7 +102,7 @@ export default class DocumentationRoot extends React.Component<RouteComponentPro
             <ExploreSideNav />
             <div className={classNames('vads-l-col--12', 'medium-screen:vads-l-col--8')}>
               <Switch>
-                { !validCategory &&
+                { !shouldRouteCategory &&
                   <Redirect from="/explore/:apiCategoryKey" to="/explore" />
                 }
                 <Route exact={true} path="/explore/" component={DocumentationOverview} />


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3704

If the category key in a developer portal URL is unknown the user will be redirected back to the `explore` page. `/explore/invalid` -> `/explore`