### PR TITLE
 Add CI script to prevent images being mistakenly added.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ node('vetsgov-general-purpose') {
       deleteDir()
       checkout([
         $class: 'GitSCM',
-        // branches: [[name: '*/master']],
+        branches: [[name: "origin/${env.BRANCH_NAME}"]],
         doGenerateSubmoduleConfigurations: false,
         extensions: [
           [$class: 'CleanBeforeCheckout'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ node('vetsgov-general-purpose') {
 
   stage('Image Prohibition') {
 		if (!onDeployableBranch()) {
-			sh "prohibit_image_files.sh master HEAD"
+			sh "./prohibit_image_files.sh master HEAD"
 		} 
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ node('vetsgov-general-purpose') {
       deleteDir()
       checkout([
         $class: 'GitSCM',
-        branches: [[name: '*/master']],
+        // branches: [[name: '*/master']],
         doGenerateSubmoduleConfigurations: false,
         extensions: [
           [$class: 'CleanBeforeCheckout'],
@@ -107,8 +107,8 @@ node('vetsgov-general-purpose') {
         ],
         submoduleCfg: [],
         userRemoteConfigs: [[
-        credentialsId: 'va-vfs-bot',
-        url: 'https://github.com/department-of-veterans-affairs/developer-portal'
+          credentialsId: 'va-vfs-bot',
+          url: 'https://github.com/department-of-veterans-affairs/developer-portal'
         ]]
       ])
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,6 +141,12 @@ node('vetsgov-general-purpose') {
     }
   }
 
+  stage('Image Prohibition') {
+		if (!onDeployableBranch()) {
+			sh "prohibit_image_files.sh master HEAD"
+		} 
+  }
+
   stage('Security') {
     try {
       dockerImage.inside(args) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ node('vetsgov-general-purpose') {
 
   stage('Image Prohibition') {
 		if (!onDeployableBranch()) {
-			sh "./prohibit_image_files.sh master HEAD"
+			sh "./prohibit_image_files.sh origin/master HEAD"
 		} 
   }
 

--- a/prohibit_image_files.sh
+++ b/prohibit_image_files.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+function list_bad_files {
+  filename_pattern="$3"
+  maxbytes="$4"
+  git rev-list --objects "${1}".."${2}" | \
+    grep -E "$filename_pattern" | \
+      git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize) %(rest)' | \
+	(
+	  while read -r objectname objecttype objectsize path; do
+	    if [[ "$objecttype" == "blob" ]] && [[ "$objectsize" -gt "$maxbytes" ]]; then
+	      echo "$path"
+	    fi
+	  done
+	)
+  return 0
+}
+
+legacy_snapshots=$(list_bad_files "$1" "$2" "src/__image_snapshots__" 0)
+if [[ -n "$legacy_snapshots" ]]; then
+  echo ""
+  echo "-----------------------------------------------------------------------------"
+  echo "Please do not commit images to src/__image_snapshots__. We've stopped"
+  echo "commiting visual regression tests directly to the repository. We now use"
+  echo "git-lfs to store pointers to externally-managed files in test/image_snapshots"
+  echo "-----------------------------------------------------------------------------"
+  echo ""
+  echo "$legacy_snapshots"
+  exit 1
+fi
+
+raw_snapshot_files=$(list_bad_files "$1" "$2" "test/image_snapshots" 140)
+if [[ -n "$raw_snapshot_files" ]]; then
+  echo ""
+  echo "-----------------------------------------------------------------------------"
+  echo "Please do not commit raw images to test/image_snapshots. The files in"
+  echo "this directory should be git-lfs pointers. This allows us to prevent the"
+  echo "repository from bloating over time."
+  echo "-----------------------------------------------------------------------------"
+  echo ""
+  echo "$raw_snapshot_files"
+  exit 1
+fi
+
+exit 0

--- a/prohibit_image_files.sh
+++ b/prohibit_image_files.sh
@@ -5,9 +5,11 @@ set -o pipefail
 set -o nounset
 
 function list_bad_files {
+  oldref="$1"
+  newref="$2"
   filename_pattern="$3"
   maxbytes="$4"
-  git rev-list --objects "${1}".."${2}" | \
+  git rev-list --objects "${oldref}..${newref}" | \
     grep -E "$filename_pattern" | \
       git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize) %(rest)' | \
 	(
@@ -26,7 +28,8 @@ if [[ -n "$legacy_snapshots" ]]; then
   echo "-----------------------------------------------------------------------------"
   echo "Please do not commit images to src/__image_snapshots__. We've stopped"
   echo "commiting visual regression tests directly to the repository. We now use"
-  echo "git-lfs to store pointers to externally-managed files in test/image_snapshots"
+  echo "git-lfs to store pointers to externally-managed files in test/image_snapshots."
+  echo "Please see docs/development.md for more info about git-lfs."
   echo "-----------------------------------------------------------------------------"
   echo ""
   echo "$legacy_snapshots"
@@ -39,7 +42,8 @@ if [[ -n "$raw_snapshot_files" ]]; then
   echo "-----------------------------------------------------------------------------"
   echo "Please do not commit raw images to test/image_snapshots. The files in"
   echo "this directory should be git-lfs pointers. This allows us to prevent the"
-  echo "repository from bloating over time."
+  echo "repository from bloating over time. Please see docs/development.md for more"
+  echo "info about git-lfs."
   echo "-----------------------------------------------------------------------------"
   echo ""
   echo "$raw_snapshot_files"


### PR DESCRIPTION
In [another PR](https://github.com/department-of-veterans-affairs/developer-portal/pull/298) I moved the image snapshots over to git-lfs. This adds a CI script to fail PRs that add new images to the relevant directories.