### PR TITLE
Add release note for Veteran Confirmation API launch

### DIFF
--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -12,6 +12,12 @@ Create Address Validation API
 
 # Veteran Confirmation
 
+## January 13, 2020
+Launched Veteran Confirmation API with a status endpoint
+- `/status`: Allows third-parties to request confirmation from the VA of an individual's Veteran status after providing a valid API key and identifying attributes for the individual.
+
+[View code change(s)](https://github.com/department-of-veterans-affairs/vets-api/pull/3676)
+
 ---
 
 <div id="veteran-verification" />


### PR DESCRIPTION
This PR addresses [#3658](https://github.com/department-of-veterans-affairs/vets-contrib/issues/3658). It adds a release note for the launch of the Veteran Confirmation API. 

It is targeted against the branch that has a PR to add Veteran Confirmation to the developer portal in #305.