### PR TITLE
Fix OAuth docs re: expires_in field.

### DIFF
--- a/src/content/apiDocs/oauthTechnical.mdx
+++ b/src/content/apiDocs/oauthTechnical.mdx
@@ -131,7 +131,7 @@ Pragma: no-cache
 
 {
   "access_token": "SlAV32hkKG",
-  "expires_at": 1553270937,
+  "expires_in": 3600,
   "refresh_token": "8xLOxBtZp8",
   "scope": "openid profile email offline_access",
   "state": "af0ifjsldkj",


### PR DESCRIPTION
[We fixed a bug in the oauth-proxy](https://github.com/department-of-veterans-affairs/vets-contrib/issues/4015). It was outputting a bogus `expires_at` field that would have been ignored by client applications. It now outputs the standard `expires_in` field, so the docs are being updated to reflect this.