### PR TITLE
Add release note for new fields

### DIFF
--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -24,6 +24,12 @@ Launched Veteran Confirmation API with a status endpoint
 
 # Veteran Verification
 
+## March 17, 2020
+Added pay grade information to service_history endpoint.
+- `/service_history`: Adds pay_grade_code and separation_reason fields to /service_history responses.
+[View code change(s)](https://github.com/department-of-veterans-affairs/vets-api/pull/4016)
+---
+
 ## November 8, 2018
 Launched the Disability Rating and Veteran Status endpoints
 - `/disability_rating`: Given an authenticated user, this created an endpoint that returns a Veteran's disability rating from VA

--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -26,7 +26,7 @@ Launched Veteran Confirmation API with a status endpoint
 
 ## March 18, 2020
 Added pay grade information to service_history endpoint.
-- `/service_history`: Adds pay_grade_code and separation_reason fields to /service_history responses.
+- `/service_history`: Adds `pay_grade_code` and `separation_reason` fields to responses.
 
 [View code change(s)](https://github.com/department-of-veterans-affairs/vets-api/pull/4016)
 

--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -24,7 +24,7 @@ Launched Veteran Confirmation API with a status endpoint
 
 # Veteran Verification
 
-## March 17, 2020
+## March 18, 2020
 Added pay grade information to service_history endpoint.
 - `/service_history`: Adds pay_grade_code and separation_reason fields to /service_history responses.
 
@@ -39,7 +39,6 @@ Launched the Disability Rating and Veteran Status endpoints
 
 ---
 
-## June 11, 2018 
+## June 11, 2018
 Launched the Service History endpoint
 - `/service_history`: Given an authenticated user, this created an endpoint that returns a Veteran's service history from VA
-

--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -27,7 +27,9 @@ Launched Veteran Confirmation API with a status endpoint
 ## March 17, 2020
 Added pay grade information to service_history endpoint.
 - `/service_history`: Adds pay_grade_code and separation_reason fields to /service_history responses.
+
 [View code change(s)](https://github.com/department-of-veterans-affairs/vets-api/pull/4016)
+
 ---
 
 ## November 8, 2018


### PR DESCRIPTION
This PR addresses IN-21. It adds a release note for the addition of pay_grade_code and separation_reason for the Veteran Verification API.

The corresponding vets-api PR is https://github.com/department-of-veterans-affairs/vets-api/pull/4016

![Veteran-Verification-Release-Note-New-Text](https://user-images.githubusercontent.com/43859081/76974778-00a9bc00-6908-11ea-88d3-4ab99fcf90dd.PNG)
