### PR TITLE
Added release note for Veteran Verification API

### DIFF
--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -24,7 +24,7 @@ Launched Veteran Confirmation API with a status endpoint
 
 # Veteran Verification
 
-## April 13, 2020
+## April 15, 2020
 Added Veteran First & Last Name to service_history endpoint.
 - `/service_history`: Adds `first_name` and `last_name` fields to responses.
 

--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -24,6 +24,14 @@ Launched Veteran Confirmation API with a status endpoint
 
 # Veteran Verification
 
+## April 13, 2020
+Added Veteran First & Last Name to service_history endpoint.
+- `/service_history`: Adds `first_name` and `last_name` fields to responses.
+
+[View code change(s)](https://github.com/department-of-veterans-affairs/vets-api/pull/4121)
+
+---
+
 ## March 18, 2020
 Added pay grade information to service_history endpoint.
 - `/service_history`: Adds `pay_grade_code` and `separation_reason` fields to responses.


### PR DESCRIPTION
In order to prevent fraud, consumers of the Veteran Verification API want to verify the Veteran data from VA matches the person applying on USAJobs. To facilitate this, PIV-308 directs the addition of Veteran First & Last name to the service history response.

Feature request.
https://vasdvp.atlassian.net/browse/PIV-308

Corresponding vets-api PR.
https://github.com/department-of-veterans-affairs/vets-api/pull/4121