### PR TITLE
Fix Appeals Version Number

### DIFF
--- a/src/apiDefs/data/appeals.ts
+++ b/src/apiDefs/data/appeals.ts
@@ -7,7 +7,7 @@ const appealsApis : IApiDescription[] = [
     docSources: [
       {
         // metadataUrl: ,// metadata endpoint is not yet exposed
-        openApiUrl: `${swaggerHost}/services/appeals/docs/v3/decision_reviews`,
+        openApiUrl: `${swaggerHost}/services/appeals/docs/v1/decision_reviews`,
       },
     ],
     enabledByDefault: false,

--- a/src/content/apiDocs/appeals/appealsReleaseNotes.mdx
+++ b/src/content/apiDocs/appeals/appealsReleaseNotes.mdx
@@ -2,6 +2,6 @@
 
 # Decision Reviews
 ## Month 99, 2099
-(v3) These are dummy release notes.  Link to PRs here!
+(v1) These are dummy release notes.  Link to PRs here!
 
 ---


### PR DESCRIPTION
The current version number has been changed from v3 to v1 (to match vets-api, and not Caseflow)