### PR TITLE
Update facilities documentation to not show version selector

### DIFF
--- a/src/apiDefs/data/facilities.ts
+++ b/src/apiDefs/data/facilities.ts
@@ -6,7 +6,6 @@ const facilitiesApis : IApiDescription[] = [
     description: "VA Facilities",
     docSources: [
       {
-        metadataUrl: `${swaggerHost}/services/va_facilities/metadata`,
         openApiUrl: `${swaggerHost}/services/va_facilities/docs/v0/api`,
       },
     ],

--- a/src/apiDefs/query.test.ts
+++ b/src/apiDefs/query.test.ts
@@ -29,7 +29,6 @@ describe('query module', () => {
         description: "VA Facilities",
         docSources: [
           {
-            metadataUrl: 'http://localhost:3000/services/va_facilities/metadata',
             openApiUrl: 'http://localhost:3000/services/va_facilities/docs/v0/api',
           },
         ],


### PR DESCRIPTION
This PR addresses [API-196](https://vajira.max.gov/browse/API-196). It removes the version selector from the Facilities API since only one version is currently available.