### PR TITLE
Change URL for apply to new developer-portal-backend

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -159,7 +159,7 @@ export const submitForm: ActionCreator<SubmitFormThunk> = () => {
     const request = new Request(
       `${
         process.env.REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL
-      }/services/meta/developer_application`,
+      }/internal/developer-portal-backend/developer_application`,
       {
         body: JSON.stringify(applicationBody),
         headers: {


### PR DESCRIPTION
This PR supports [API-180](https://vajira.max.gov/browse/API-180). It points the developer portal apply page at the new developer-portal-backend, which is exposed through the gateway at `/internal/developer-portal-backend`.

The new backend lives in the repo: https://github.com/department-of-veterans-affairs/developer-portal-backend/

Changes to expose it through the gateway happened here: https://github.com/department-of-veterans-affairs/devops/pull/6815