### PR TITLE
Add tests of cached application state

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,9 +1,8 @@
 import { initialApplicationState } from './reducers';
 
-// sessionStorage.getItem('state') is called when the store is imported at application start up
-// to be able to pass in artibray values for testing purposes, 
-// the store is reset between tests and the initialized after setting sessionStorage 
-let store: any;
+// sessionStorage.getItem('state') is called when the store is imported at application start up.
+// To be able to pass in artibray values for testing purposes, the store is reset between tests 
+// and then initialized after setting sessionStorage.
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -11,22 +10,24 @@ beforeEach(() => {
 });
 
 describe('loadApplicationState', () => {
-  it('returns a blank application when sessionStorage is empty', () => {
-    store = require('./store').default;
+  it('returns a blank application when sessionStorage is empty', async () => {
+    const store = (await import('./store')).default;
     const state = store.getState();
     expect(state.application).toEqual(initialApplicationState);
   });
 
-  it('returns the cached application when available', () => {
-    sessionStorage.setItem('state', '{"application":{"inputs":{"apis":{"appeals":false,"benefits":false,"claims":false,"communityCare":false,"confirmation":false,"facilities":false,"health":false,"vaForms":false,"verification":false},"description":{"dirty":false,"value":""},"email":{"dirty":false,"value":""},"firstName":{"dirty":false,"value":"Test"},"lastName":{"dirty":false,"value":"User"},"oAuthApplicationType":{"dirty":false,"value":""},"oAuthRedirectURI":{"dirty":false,"value":""},"organization":{"dirty":false,"value":""},"termsOfService":false}}}');
-    store = require('./store').default;
+  it('returns the cached application when available', async () => {
+    const savedState = '{"application":{"inputs":{"apis":{"appeals":false,"benefits":false,"claims":false,"communityCare":false,"confirmation":false,"facilities":false,"health":false,"vaForms":false,"verification":false},"description":{"dirty":false,"value":""},"email":{"dirty":false,"value":""},"firstName":{"dirty":false,"value":"Test"},"lastName":{"dirty":false,"value":"User"},"oAuthApplicationType":{"dirty":false,"value":""},"oAuthRedirectURI":{"dirty":false,"value":""},"organization":{"dirty":false,"value":""},"termsOfService":false}}}';
+    sessionStorage.setItem('state', savedState);
+    const store = (await import('./store')).default;
     const state = store.getState();
-    expect(state.application).not.toEqual(initialApplicationState);
+    expect(state.application).toEqual(JSON.parse(savedState).application);
   });
 
-  it('returns a blank application when the form schema has changed', () => {
-    sessionStorage.setItem('state', '{"application":{"inputs":{"apis":{"appeals":false,"benefits":false,"claims":false,"communityCare":false,"confirmation":false,"facilities":false,"health":false,"vaForms":false,"verification":false},"description":{"dirty":false,"value":""},"email":{"dirty":false,"value":""},"firstName":{"dirty":false,"value":"Test"},"middleName":{"dirty":false,"value":"This"},"lastName":{"dirty":false,"value":"User"},"oAuthApplicationType":{"dirty":false,"value":""},"oAuthRedirectURI":{"dirty":false,"value":""},"organization":{"dirty":false,"value":""},"termsOfService":false}}}');
-    store = require('./store').default;
+  it('returns a blank application when the form schema has changed', async () => {
+    const saveState = '{"application":{"inputs":{"apis":{"appeals":false,"benefits":false,"claims":false,"communityCare":false,"confirmation":false,"facilities":false,"health":false,"vaForms":false,"verification":false},"description":{"dirty":false,"value":""},"email":{"dirty":false,"value":""},"firstName":{"dirty":false,"value":"Test"},"middleName":{"dirty":false,"value":"This"},"lastName":{"dirty":false,"value":"User"},"oAuthApplicationType":{"dirty":false,"value":""},"oAuthRedirectURI":{"dirty":false,"value":""},"organization":{"dirty":false,"value":""},"termsOfService":false}}}';
+    sessionStorage.setItem('state', saveState);
+    const store = (await import('./store')).default;
     const state = store.getState();
     expect(state.application).toEqual(initialApplicationState);
   });

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,33 @@
+import { initialApplicationState } from './reducers';
+
+// sessionStorage.getItem('state') is called when the store is imported at application start up
+// to be able to pass in artibray values for testing purposes, 
+// the store is reset between tests and the initialized after setting sessionStorage 
+let store: any;
+
+beforeEach(() => {
+  sessionStorage.clear();
+  jest.resetModules();
+});
+
+describe('loadApplicationState', () => {
+  it('returns a blank application when sessionStorage is empty', () => {
+    store = require('./store').default;
+    const state = store.getState();
+    expect(state.application).toEqual(initialApplicationState);
+  });
+
+  it('returns the cached application when available', () => {
+    sessionStorage.setItem('state', '{"application":{"inputs":{"apis":{"appeals":false,"benefits":false,"claims":false,"communityCare":false,"confirmation":false,"facilities":false,"health":false,"vaForms":false,"verification":false},"description":{"dirty":false,"value":""},"email":{"dirty":false,"value":""},"firstName":{"dirty":false,"value":"Test"},"lastName":{"dirty":false,"value":"User"},"oAuthApplicationType":{"dirty":false,"value":""},"oAuthRedirectURI":{"dirty":false,"value":""},"organization":{"dirty":false,"value":""},"termsOfService":false}}}');
+    store = require('./store').default;
+    const state = store.getState();
+    expect(state.application).not.toEqual(initialApplicationState);
+  });
+
+  it('returns a blank application when the form schema has changed', () => {
+    sessionStorage.setItem('state', '{"application":{"inputs":{"apis":{"appeals":false,"benefits":false,"claims":false,"communityCare":false,"confirmation":false,"facilities":false,"health":false,"vaForms":false,"verification":false},"description":{"dirty":false,"value":""},"email":{"dirty":false,"value":""},"firstName":{"dirty":false,"value":"Test"},"middleName":{"dirty":false,"value":"This"},"lastName":{"dirty":false,"value":"User"},"oAuthApplicationType":{"dirty":false,"value":""},"oAuthRedirectURI":{"dirty":false,"value":""},"organization":{"dirty":false,"value":""},"termsOfService":false}}}');
+    store = require('./store').default;
+    const state = store.getState();
+    expect(state.application).toEqual(initialApplicationState);
+  });
+});


### PR DESCRIPTION
Added tests for the store to verify that the apply page is only using cached sessionStorage data when appropriate. As the function `loadApplicationState` is not exported I chose to dynamically import the store in each test to reinitialize it after loading the appropriate value into sessionStorage.