### PR TITLE
Update sandbox migration banner

### DIFF
--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -90,7 +90,7 @@ function AlertNotice() {
           <h2 className="usa-alert-heading" id="alert-heading">VA Lighthouse Development Sandbox Migration</h2>
           <div className="usa-alert-text">
             <p>
-              All consumer access to dev-api.va.gov will be <strong>permanently removed on May 1, 2020</strong>. To ensure a smooth transition to our new Sandbox environment, update all references of dev-api.va.gov to <strong>sandbox-api.va.gov</strong>. For more details, visit the <strong><a href="https://groups.google.com/forum/#!topic/va-lighthouse/aBDqzVyiaXo" target="_blank">VA Lighthouse Forum</a></strong> and <strong><a href="https://valighthouse.statuspage.io/" target="_blank">subscribe to updates</a></strong>.
+              Consumer access to dev-api.va.gov was removed on May 1, 2020. It’s been replaced with with our new Sandbox environment, sandbox-api.va.gov. For more details, visit the <strong><a href="https://groups.google.com/forum/#!topic/va-lighthouse/aBDqzVyiaXo" target="_blank">VA Lighthouse Forum</a></strong> and <strong><a href="https://valighthouse.statuspage.io/" target="_blank">subscribe to updates</a></strong>.
             </p>
           </div>
         </div>

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -90,7 +90,7 @@ function AlertNotice() {
           <h2 className="usa-alert-heading" id="alert-heading">VA Lighthouse Development Sandbox Migration</h2>
           <div className="usa-alert-text">
             <p>
-              Consumer access to dev-api.va.gov was removed on May 1, 2020. It’s been replaced with with our new Sandbox environment, sandbox-api.va.gov. For more details, visit the <strong><a href="https://groups.google.com/forum/#!topic/va-lighthouse/aBDqzVyiaXo" target="_blank">VA Lighthouse Forum</a></strong> and <strong><a href="https://valighthouse.statuspage.io/" target="_blank">subscribe to updates</a></strong>.
+              Consumers' access to dev-api.va.gov was removed on May 1, 2020, and has been migrated to our new Sandbox environment: sandbox-api.va.gov. For more details, visit the <strong><a href="https://groups.google.com/forum/#!topic/va-lighthouse/aBDqzVyiaXo" target="_blank">VA Lighthouse Forum</a></strong> and <strong><a href="https://valighthouse.statuspage.io/" target="_blank">subscribe to updates</a></strong>.
             </p>
           </div>
         </div>

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-1-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ddfc3d100aeba8c70793d3f3545243b1a95d6dbb6426af5cfb0fe7e04ca5b5d
-size 163516
+oid sha256:83bffc7dd7711e5878a180d58cfad771212b7f3ab66884d0a6bd46cf1c4cd659
+size 157520

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-3-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-3-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d83fd55e89fae37f557b7f2136296db4eecb81bbe4d2a828e54ae43b7271550
-size 147234
+oid sha256:b5162f765e2734e6a9f746a18c24b66953b6d224e84b6cc3b9a2a2b567e3ac41
+size 141929


### PR DESCRIPTION
This PR updates the language in the banner warning for consumers needing to migrate from dev to sandbox now that the cutover has happened.