### PR TITLE
Added Veteran Verification release note for combined disability rating

### DIFF
--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -26,8 +26,8 @@ Launched Veteran Confirmation API with a status endpoint
 
 ## May 11, 2020
 Added combined disability rating and individual disability ratings to the disability_rating endpoint.
-• `/disability_rating` endpoint: Adds `combined_disability_rating` field to responses. This is expressed as a percentage and represents how much a Veteran’s disability decreases their overall health and ability to function.
-• `/disability_rating` endpoint: Adds `individual_ratings` array to responses with each entry representing whether the individual condition is service related, when the Veteran could begin claiming benefits related to this disability, and the disability rating for the individual condition expressed as a percentage.
+- `/disability_rating` endpoint: Adds `combined_disability_rating` field to responses. This is expressed as a percentage and represents how much a Veteran’s disability decreases their overall health and ability to function.
+- `/disability_rating` endpoint: Adds `individual_ratings` array to responses with each entry representing whether the individual condition is service related, when the Veteran could begin claiming benefits related to this disability, and the disability rating for the individual condition expressed as a percentage.
 
 [View code changes(s)](https://github.com/department-of-veterans-affairs/vets-api/pull/4223)
 

--- a/src/content/apiDocs/verification/verificationReleaseNotes.mdx
+++ b/src/content/apiDocs/verification/verificationReleaseNotes.mdx
@@ -24,6 +24,15 @@ Launched Veteran Confirmation API with a status endpoint
 
 # Veteran Verification
 
+## May 11, 2020
+Added combined disability rating and individual disability ratings to the disability_rating endpoint.
+• `/disability_rating` endpoint: Adds `combined_disability_rating` field to responses. This is expressed as a percentage and represents how much a Veteran’s disability decreases their overall health and ability to function.
+• `/disability_rating` endpoint: Adds `individual_ratings` array to responses with each entry representing whether the individual condition is service related, when the Veteran could begin claiming benefits related to this disability, and the disability rating for the individual condition expressed as a percentage.
+
+[View code changes(s)](https://github.com/department-of-veterans-affairs/vets-api/pull/4223)
+
+---
+
 ## April 15, 2020
 Added Veteran First & Last Name to service_history endpoint.
 - `/service_history`: Adds `first_name` and `last_name` fields to responses.


### PR DESCRIPTION
Added Veteran Verification API release note to document the new `combined_disability_rating` field and movement of top level ratings into an `individual_ratings` array for clarity to consumers.