### PR TITLE
Removing sandbox migration banner

### DIFF
--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -82,30 +82,12 @@ function VeteransNotice() {
   );
 }
 
-function AlertNotice() {
-  return (
-    <section className="usa-alert-full-width usa-alert-full-width-warning vads-u-background-color--gibill-accent vads-u-border-top--0" role="region" aria-labelledby="alert-heading">
-      <div className="usa-alert usa-alert-warning vads-u-background-color--gibill-accent" aria-live="polite" role="alert">
-        <div className="usa-alert-body">
-          <h2 className="usa-alert-heading" id="alert-heading">VA Lighthouse Development Sandbox Migration</h2>
-          <div className="usa-alert-text">
-            <p>
-              Consumers' access to dev-api.va.gov was removed on May 1, 2020, and has been migrated to our new Sandbox environment: sandbox-api.va.gov. For more details, visit the <strong><a href="https://groups.google.com/forum/#!topic/va-lighthouse/aBDqzVyiaXo" target="_blank">VA Lighthouse Forum</a></strong> and <strong><a href="https://valighthouse.statuspage.io/" target="_blank">subscribe to updates</a></strong>.
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
 class Home extends React.Component {
   public render() {
     return (
       <div className="home">
         <Hero />
         <VeteransNotice />
-        <AlertNotice />
         <HomeSection ariaLabel="An API platform" imageSrc={padlockImg} title="A secure API platform to service Veterans.">
           <div>
             Lighthouse is an API platform that gives developers secure access to the VA data they need to build helpful tools and services for Veterans.

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-1-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83bffc7dd7711e5878a180d58cfad771212b7f3ab66884d0a6bd46cf1c4cd659
-size 157520
+oid sha256:8372dda088c33ee6c2b2e443687bcb7ddc2d0ed59bebda0285ae4368acad590e
+size 137822

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-2-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:695c2d25acdfc4f189b67e8d2ab02b57d0f26f192dcb08a06fdfb2319d2485cf
-size 167017
+oid sha256:01c393ff973e591ee6f7169dc40899ee4063368de397502d910e74119c38f33d
+size 141647

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-3-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-the-homepage-properly-3-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5162f765e2734e6a9f746a18c24b66953b6d224e84b6cc3b9a2a2b567e3ac41
-size 141929
+oid sha256:a0745ef41a4dc0b914077805b72ae242ab437ef043211b128b290a4cb52afbc9
+size 116058


### PR DESCRIPTION
Now that consumers have been removed from dev-api.va.gov for two weeks we are removing the banner reminding consumers to migrate to sandbox-api.va.gov. For https://vajira.max.gov/browse/API-890,