### PR TITLE
Allow mobile nav menu to scroll for zoomed-in screens

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,15 +12,15 @@ import Search from './Search';
 import './Header.scss';
 import TestingNotice from './TestingNotice';
 
-interface INavBarState {
-  menuVisible: boolean;
+interface IHeaderState {
+  mobileNavVisible: boolean;
 }
 
-export default class Header extends React.Component<{}, INavBarState> {
+export default class Header extends React.Component<{}, IHeaderState> {
   constructor(props: {}) {
     super(props);
     this.state = {
-      menuVisible: false,
+      mobileNavVisible: false,
     };
   }
 
@@ -82,15 +82,15 @@ export default class Header extends React.Component<{}, INavBarState> {
               </button>
             </div>
           </div>
-          <NavBar isMobileMenuVisible={this.state.menuVisible} onClose={navBarCloseHandler} />
+          <NavBar isMobileMenuVisible={this.state.mobileNavVisible} onClose={navBarCloseHandler} />
         </header>
       </React.Fragment>
     );
   }
 
   private toggleMenuVisible = () => {
-    this.setState((state: INavBarState) => {
-      return { menuVisible: !state.menuVisible };
+    this.setState((state: IHeaderState) => {
+      return { mobileNavVisible: !state.mobileNavVisible };
     });
   }
 }

--- a/src/components/NavBar.scss
+++ b/src/components/NavBar.scss
@@ -9,10 +9,12 @@
   top: 0;
   right: 0;
   bottom: 0;
+  overflow-y: scroll;
   
   @include media($medium-screen) {
     background-color: $color-primary-darkest;
     position: relative;
+    overflow-y: visible;
   }
 
   &.va-api-mobile-nav-visible {


### PR DESCRIPTION
completes [API-937](https://vajira.max.gov/browse/API-937).

allows the mobile menu, which also appears on desktop for zoomed-in screens, to scroll when the screen is zoomed in at 400% or greater to comply with WCAG standards. 

* WCAG 2.1 [Success Criterion 1.4.10: Reflow](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) requires that the content be presented in such a way that the user can zoom in at 400% or greater without loss of content and without requiring scrolling in two dimensions. technically, the standard requires these conditions be met for a viewport equivalent to a width of 320 CSS pixels and a height of CSS pixels - in other words, a viewport that is 1280 pixels wide and 1024 pixels high at 100% zoom zoomed in to 400%.

screenshot of the problem before fix:

<img width="1279" alt="ZoomedMobileMenu" src="https://user-images.githubusercontent.com/3241493/82471229-6c3d1080-9a94-11ea-8362-30024ffed5e1.png">

also renamed some things in `Header`, where `NavBar` is consumed, because the names were annoying/inaccurate.