### PR TITLE
Cutover support email to developer-portal-backend implementation

### DIFF
--- a/src/containers/support/SupportContactUsForm.tsx
+++ b/src/containers/support/SupportContactUsForm.tsx
@@ -197,10 +197,5 @@ export default class SupportContactUsForm extends React.Component<ISupportContac
     if (!response.ok) {
       throw Error(response.statusText);
     }
-
-    const json = await response.json();
-    if (json && json.statusCode !== 200) {
-      throw Error(json.body);
-    }
   }
 }

--- a/src/containers/support/SupportContactUsForm.tsx
+++ b/src/containers/support/SupportContactUsForm.tsx
@@ -182,7 +182,7 @@ export default class SupportContactUsForm extends React.Component<ISupportContac
 
   private async formSubmission() {
     const request = new Request(
-      `${process.env.REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL}/services/meta/contact-us`,
+      `${process.env.REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL}/internal/developer-portal-backend/contact-us`,
       {
         body: JSON.stringify(this.processedData),
         headers: {


### PR DESCRIPTION
This PR supports [API-178](https://vajira.max.gov/browse/API-178). It cuts over the developer portal to use the support email implementation in the `developer-portal-backend` [created in this PR](https://github.com/department-of-veterans-affairs/developer-portal-backend/pull/52). The new route it's sending to is [configured here in devops](https://github.com/department-of-veterans-affairs/devops/blob/e0e7c47636bd8b4c858f7a76d67ca7eb251e1282/lighthouse/gateway/kong_configs/prod_kong.yml#L1646).