### PR TITLE
Add proposed codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,3 @@
 # Interrobang manages the structural code for developer-portal.
 * @department-of-veterans-affairs/lighthouse-interrobang
 
-# Everyone owns review of the content until UX takes over.
-/src/content @department-of-veterans-affairs/lighthouse-apis

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Interrobang manages the structural code for developer-portal.
+* @department-of-veterans-affairs/lighthouse-interrobang
+
+# Everyone owns review of the content until UX takes over.
+/src/content @department-of-veterans-affairs/lighthouse-apis


### PR DESCRIPTION
This PR sets up Interrobang as codeowners for the developer-portal repository with one exception: everyone in `lighthouse-apis` would own the `src/content` directory where release notes, news, and documentation live.

This configuration will create noise for members of `lighthouse-apis`, many of who will not care about documentation changes. If we want everyone to be able to approve their own documentation PRs until UX takes over review in the future, this is the only way. Codeowners does not currently support a negation syntax where we could exclude requiring Interrobang for review of `src/content`. 

Alternatively, Interrobang could serve as codeowners of the entire repository and rubberstamp the currently infrequent documentation changes. 