### PR TITLE
Tweak release notes header

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -25,3 +25,17 @@ References:
 * `zenscroll` [event listener](https://github.com/zengabor/zenscroll/blob/dist/zenscroll.js#L305)
 * [The `event.preventDefault()` call](https://github.com/zengabor/zenscroll/blob/dist/zenscroll.js#L336)
 * [Slack thread](https://lighthouseva.slack.com/archives/CSZN6V1CH/p1591980406369000) from the investigation that uncovered this issue
+
+## Content
+
+### API Category Names
+
+The pseudo-schema for API categories in `src/apiDefs/categories.ts` currently includes two fields for the category name, `name` and `properName`. `name` is used in most places; `properName` is most likely a legacy of some earlier presentational needs.
+
+`properName` is sometimes the same as `name` (Appeals, Health), and it is semantically incorrect in at least one case ("Benefits Intake API" for the Benefits category).
+
+`properName` is only used in the following place:
+
+* The `ApplySuccess` page uses `properName` as the display name for Benefits, Facilities, and VA Forms. (Note that the Apply page doesn't maintain a clear distinction between individual APIs and API categories.)
+
+We should eliminate `properName` from the category schema as soon as possible, assuming that we can confirm that we can safely do that with UX.

--- a/src/containers/documentation/QuickstartPage.tsx
+++ b/src/containers/documentation/QuickstartPage.tsx
@@ -11,11 +11,11 @@ export default class QuickstartPage extends React.Component<RouteComponentProps<
     const { apiCategoryKey } = this.props.match.params;
     const { 
       content: { quickstart: quickstartContent }, 
-      properName,
+      name,
     } = getApiDefinitions()[apiCategoryKey];
 
     if (quickstartContent) {
-      return <QuickstartWrapper halo={properName} quickstartContent={quickstartContent} />;
+      return <QuickstartWrapper halo={name} quickstartContent={quickstartContent} />;
     } else {
       return <Redirect to={`/explore/${apiCategoryKey}`} />;
     }

--- a/src/containers/releaseNotes/CategoryReleaseNotesPage.tsx
+++ b/src/containers/releaseNotes/CategoryReleaseNotesPage.tsx
@@ -32,14 +32,8 @@ export default class CategoryReleaseNotesPage extends React.Component<
     const apiDefs = getApiDefinitions();
     const { apiCategoryKey } = this.props.match.params;
     const { apis } = apiDefs[apiCategoryKey];
-
-    const headerProps = {
-      halo: 'Release Notes',
-      header: apiDefs[apiCategoryKey].properName,
-    };
-
+    
     let cardSection;
-
     if (apis.length > 1) {
       const apiCards = apis.map((apiDesc: IApiDescription) => {
         const { description, name, urlFragment, vaInternalOnly, trustedPartnerOnly } = apiDesc;
@@ -73,7 +67,7 @@ export default class CategoryReleaseNotesPage extends React.Component<
 
     return (
       <section role="region" aria-labelledby={`${apiCategoryKey}-release-notes`}>
-        <PageHeader halo={headerProps.halo} header={headerProps.header} />
+        <PageHeader halo={apiDefs[apiCategoryKey].name} header="Release Notes" />
         {cardSection}
         <div className={classNames('vads-u-width--full', 'vads-u-margin-top--4')}>
           {apis.map(api => <ApiReleaseNote key={api.urlFragment} api={api} />)}

--- a/src/containers/releaseNotes/ReleaseNotesOverview.tsx
+++ b/src/containers/releaseNotes/ReleaseNotesOverview.tsx
@@ -10,7 +10,7 @@ export default () => {
   const apiDefs = getApiDefinitions();
   return (
     <div>
-      <PageHeader halo="Release Notes" header="Overview" />
+      <PageHeader halo="Overview" header="Release Notes" />
       <div className="vads-u-font-size--lg">
         <p>
           The VA Lighthouse product teams periodically update these APIs in order to deliver new features and repair defects. We avoid doing so whenever possible but occasionally we need to make breaking changes that require developers to modify their existing applications to see the benefits of these features and fixes.


### PR DESCRIPTION
completes [API-1329](https://vajira.max.gov/browse/API-1329).

i documented the `properName` category field in `issues.md` for future reference. hopefully we can get rid of it soon. i also removed it from the Quickstart page because both categories that have a Quickstart have identical `name` and `properName` values.