### PR TITLE
Change Google Search Console owner

### DIFF
--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -87,7 +87,7 @@ module.exports = function(proxy, allowedHost) {
       // folder will receive the generated index.html contents.
       rewrites: [
         { from: /favicon.ico/, to: '/favicon.ico' },
-        { from: /google6289781a233ec55f.html/, to: '/google6289781a233ec55f.html' },
+        { from: /google42fbb5f81dacc35d.html/, to: '/google42fbb5f81dacc35d.html' },
         { from: /robots.txt/, to: '/robots.txt' },
       ]
     },

--- a/public/google42fbb5f81dacc35d.html
+++ b/public/google42fbb5f81dacc35d.html
@@ -1,0 +1,1 @@
+google-site-verification: google42fbb5f81dacc35d.html

--- a/public/google6289781a233ec55f.html
+++ b/public/google6289781a233ec55f.html
@@ -1,1 +1,0 @@
-google-site-verification: google6289781a233ec55f.html


### PR DESCRIPTION
### Description
<!-- 
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->
This PR removes Jeff Dunn and adds myself as an owner of the Google Search Console for the developer portal. The Google Search Console allows us to look at the searches performed by search.usa.gov through through the search bar on the developer portal. Google verifies ownership by checking an html file that is included in builds of the developer portal. More info on this verification can be found [here](https://support.google.com/webmasters/answer/9008080#html_verification).

Jeff has also added @charleystran and @bastosmichael as owners. Their verifications can be added in the same way.

PR that added Jeff: https://github.com/department-of-veterans-affairs/developer-portal/pull/71
