### PR TITLE
Update to Node 12 for build process and add in lib required to launch…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # based on https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
 
-FROM node:10
+FROM node:12
 
 # Install chromium dependencies
-RUN apt-get update && apt-get install -y wget --no-install-recommends \
+RUN apt-get update && apt-get install -y libxss1 wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
@@ -23,6 +23,8 @@ RUN groupadd --gid 504 jenkins \
 
 USER jenkins
 
+# Change default global node module directory
+RUN mkdir ~/.npm-global && npm config set prefix '~/.npm-global' && export PATH=~/.npm-global/bin:$PATH
 RUN npm install -g npm
 RUN npm install -g @sentry/cli
 


### PR DESCRIPTION
### Description
<!-- 
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->
This PR supports [API-1322](https://vajira.max.gov/browse/API-1322). It changes the Node version used by Jenkins to Node 12 to stay up-to-date with the LTS version. It also fixes an issue with Puppeteer where chrome would not launch properly in CI.

**Notable changes**
- Added a step to create a directory to store global node modules. Attempting to install them in `/usr/local` by default fails in Node 12 for a non-root user. This can live in the Jenkins user's home directory instead.
- Installs `libxss1` dependency. This was reported as missing by some [failing CI jobs in Jenkins](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fdeveloper-portal/detail/master/330/pipeline). Specifically the error said: 
```
Error: Failed to launch chrome!
/application/node_modules/puppeteer/.local-chromium/linux-650583/chrome-linux/chrome: error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory
```
[Troubleshooting documentation for Puppeteer](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix) shows the dependencies required for Chrome to run on Debian. To figure out which ones are missing, you can run `ldd path/to/chrome | grep not`. In our case, that command was `ldd node_modules/puppeteer/.local-chromium/linux-650583/chrome-linux/chrome | grep not`, which only returned one missing package: `libXss.so.1 => not found`.

### Process
<!-- 
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation 
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them. 
-->
- [x] Tests added or updated for change
Tests were definitely updated... to actually work.
- [x] Docs updated
N/A unless others think there's something to add here.
- [x] Accessibility concerns have been considered and addressed
Shouldn't be any with this!

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
