### PR TITLE
Replace Interrobang with Okapi and Quokka

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-# Interrobang manages the structural code for developer-portal.
-* @department-of-veterans-affairs/lighthouse-interrobang
+# Okapi and Quokka manage the structural code for developer-portal.
+* @department-of-veterans-affairs/lighthouse-okapi @department-of-veterans-affairs/lighthouse-quokka
 


### PR DESCRIPTION
### Description
<!-- 
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->
We have split Interrobang into Quokka (provider team) and Okapi (consumer team). Both of these teams still have a vested interest in the developer-portal repo. For now, @charleystran and I want both teams to be co-equal approvers of any PR—only one approval from either team is required to make a PR ready for merging. We may choose to assign more specific ownership in the future.

### Process
<!-- 
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation 
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them. 
-->
- [ ] Tests added or updated for change
- [ ] Docs updated
- [ ] Accessibility concerns have been considered and addressed

All are N/A for this change.

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
