### PR TITLE
Add libxtst6 to docker file dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:12
 
 # Install chromium dependencies
-RUN apt-get update && apt-get install -y libxss1 wget --no-install-recommends \
+RUN apt-get update && apt-get install -y libxss1 libxtst6 wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \


### PR DESCRIPTION
### Description
This PR supports [API-2176](https://vajira.max.gov/browse/API-2176). It adds a missing dependency for running headless chrome e2e tests.

### Process
Reviewed https://github.com/department-of-veterans-affairs/developer-portal/pull/378 because it was a similar issue and determined that the `libxtst6 ` package needed to be added to the Dockerfile for chrome (to run e2e tests in headless mode). 

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
