### PR TITLE
Move DSTU2 tab ahead of R4 tab on FHIR documentation page

### DIFF
--- a/src/apiDefs/data/health.ts
+++ b/src/apiDefs/data/health.ts
@@ -78,15 +78,15 @@ const healthApis: IApiDescription[] = [
         openApiUrl: `${swaggerHost}/services/fhir/v0/argonaut/data-query/openapi.json`,
       },
       {
-        key: 'r4',
-        label: 'R4',
-        openApiUrl: `${swaggerHost}/services/fhir/v0/r4/openapi.json`,
-      },
-      {
         apiIntro: FhirDSTU2ApiIntro,
         key: 'dstu2',
         label: 'DSTU2',
         openApiUrl: `${swaggerHost}/services/fhir/v0/dstu2/openapi.json`,
+      },
+      {
+        key: 'r4',
+        label: 'R4',
+        openApiUrl: `${swaggerHost}/services/fhir/v0/r4/openapi.json`,
       },
     ],
     enabledByDefault: true,

--- a/src/content/gettingStarted.mdx
+++ b/src/content/gettingStarted.mdx
@@ -1,3 +1,0 @@
-# About Page
-
-Some stuff here

--- a/src/content/homePage.mdx
+++ b/src/content/homePage.mdx
@@ -1,3 +1,0 @@
-## Home Page
-
-Some more content does this work?


### PR DESCRIPTION
### Description
<!-- 
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

completes [API-1626](https://vajira.max.gov/browse/API-1626) by moving the DSTU2 tab ahead of the R4 tab on the FHIR documentation page. also deleted a couple of old stub Markdown files.

### Process
<!-- 
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation 
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them. 
-->
- [n/a] Tests added or updated for change
- [n/a] Docs updated
- [n/a] Accessibility concerns have been considered and addressed

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
