### PR TITLE
API-2349/update-typescript-to-v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22001,7 +22001,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
         "asn1.js": "^4.0.0",
@@ -29244,9 +29244,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "tslint-config-prettier": "^1.10.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-react": "^3.2.0",
-    "typescript": "^3.9.7",
+    "typescript": "^4.0.3",
     "url-loader": "1.1.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/src/base.accessibility.ts
+++ b/src/base.accessibility.ts
@@ -10,7 +10,7 @@ describe('Accessibility tests', () => {
         page.on('request', mockSwagger);
       }
 
-      await page.goto(`${puppeteerHost}${path}`, { waitUntil: 'networkidle0' });
+      await page.goto(`${puppeteerHost}${path}`, { waitUntil: 'networkidle2' });
       await page.addScriptTag({ path: require.resolve('axe-core') });
 
       // THIS IS BAD. code highlighting on the Authorization page has several color contrast


### PR DESCRIPTION
### Description
Upgrades Typescript from 3.9.7 to 4.0.3 which is the latest stable release. There is 4.1 in beta currently but stuck with the stable release for all the good reasons.

### Process
- [ ] Tests added or updated for change
- [ ] Docs updated
- [ ] Accessibility concerns have been considered and addressed

### Requested feedback