### PR TITLE
API-2909: Use route hooks on PageContent

### DIFF
--- a/src/components/pageContent/PageContent.tsx
+++ b/src/components/pageContent/PageContent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router';
+import { useLocation } from 'react-router-dom';
 import { SiteRoutes } from '../../Routes';
 
 const focusAndScroll = (elementToFocus: HTMLElement | null) => {
@@ -10,11 +10,10 @@ const focusAndScroll = (elementToFocus: HTMLElement | null) => {
   window.scrollTo(0, 0);
 };
 
-const PageContent = (props: RouteComponentProps): JSX.Element => {
+const PageContent = (): JSX.Element => {
   const mainRef = React.useRef<HTMLElement>(null);
   const prevPathRef = React.useRef<string | null>(null);
-
-  const { location } = props;
+  const location = useLocation();
 
   React.useEffect(() => {
     const prevPath: string | null = prevPathRef.current;


### PR DESCRIPTION
### Description
Jira Ticket: https://vajira.max.gov/browse/API-2909

PageContent should now be using a location hook instead of receiving it as a prop.

### Process
- [N/A] Tests added or updated for change
- [N/A] Docs updated
- [N/A] Accessibility concerns have been considered and addressed

### Requested feedback
Nothing specific
