### PR TITLE
API 2911: Update QuickStart page to use Route hooks

### DIFF
--- a/src/containers/documentation/QuickstartPage.tsx
+++ b/src/containers/documentation/QuickstartPage.tsx
@@ -1,7 +1,7 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
-import { Redirect, RouteComponentProps } from 'react-router';
+import { Redirect, useParams } from 'react-router';
 
 import { getApiDefinitions } from '../../apiDefs/query';
 import QuickstartWrapper from '../../components/QuickstartWrapper';
@@ -11,8 +11,8 @@ const QuickstartPagePropTypes = {
   match: PropTypes.object.isRequired,
 };
 
-const QuickstartPage = (props: RouteComponentProps<APINameParam>): JSX.Element => {
-  const { apiCategoryKey } = props.match.params;
+const QuickstartPage = (): JSX.Element => {
+  const { apiCategoryKey } = useParams<APINameParam>();
   const {
     content: { quickstart: quickstartContent },
     name,


### PR DESCRIPTION
### Description
Jira Ticket: https://vajira.max.gov/browse/API-2911

QuickStart page should now be using a param hook instead of receiving it as a prop.

- [ n/a ] Tests added or updated for change
- [ n/a ] Docs updated
- [ n/a ] Accessibility concerns have been considered and addressed

### Requested feedback
All feedback is welcome
