### PR TITLE
API 2912:  Update Category Release Notes to use Route Hooks

### DIFF
--- a/src/containers/documentation/QuickstartPage.tsx
+++ b/src/containers/documentation/QuickstartPage.tsx
@@ -1,7 +1,7 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
-import { Redirect, RouteComponentProps } from 'react-router';
+import { Redirect, useParams } from 'react-router';
 
 import { getApiDefinitions } from '../../apiDefs/query';
 import QuickstartWrapper from '../../components/QuickstartWrapper';
@@ -11,8 +11,8 @@ const QuickstartPagePropTypes = {
   match: PropTypes.object.isRequired,
 };
 
-const QuickstartPage = (props: RouteComponentProps<APINameParam>): JSX.Element => {
-  const { apiCategoryKey } = props.match.params;
+const QuickstartPage = (): JSX.Element => {
+  const { apiCategoryKey } = useParams<APINameParam>();
   const {
     content: { quickstart: quickstartContent },
     name,

--- a/src/containers/releaseNotes/CategoryReleaseNotes.tsx
+++ b/src/containers/releaseNotes/CategoryReleaseNotes.tsx
@@ -1,7 +1,7 @@
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import classNames from 'classnames';
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router';
+import { useParams } from 'react-router';
 
 import { getDeactivatedCategory, isApiDeactivated } from '../../apiDefs/deprecated';
 import { getApiDefinitions } from '../../apiDefs/query';
@@ -88,35 +88,33 @@ interface ReleaseNotesCollectionProps {
   alertText?: string;
 }
 
-const ReleaseNotesCollection = (props: ReleaseNotesCollectionProps) => {
-  return (
-    <section role="region" aria-labelledby={`${props.categoryKey}-release-notes`}>
-      <PageHeader
-        halo={props.apiCategory.name}
-        header="Release Notes"
-        containerId={`${props.categoryKey}-release-notes`}
-      />
-      {props.alertText && (
-        <AlertBox status="info" className="vads-u-padding-y--2">
-          {props.alertText}
-        </AlertBox>
-      )}
-      <ReleaseNotesCardLinks
-        apiCategory={props.apiCategory}
-        categoryKey={props.categoryKey}
-        flagName={props.apiFlagName}
-      />
-      <div className={classNames('vads-u-width--full', 'vads-u-margin-top--4')}>
-        {props.apiCategory.apis.map((api: APIDescription) => (
-          <APIReleaseNote flagName={props.apiFlagName} key={api.urlFragment} api={api} />
-        ))}
-      </div>
-    </section>
-  );
-};
+const ReleaseNotesCollection = (props: ReleaseNotesCollectionProps) => (
+  <section role="region" aria-labelledby={`${props.categoryKey}-release-notes`}>
+    <PageHeader
+      halo={props.apiCategory.name}
+      header="Release Notes"
+      containerId={`${props.categoryKey}-release-notes`}
+    />
+    {props.alertText && (
+      <AlertBox status="info" className="vads-u-padding-y--2">
+        {props.alertText}
+      </AlertBox>
+    )}
+    <ReleaseNotesCardLinks
+      apiCategory={props.apiCategory}
+      categoryKey={props.categoryKey}
+      flagName={props.apiFlagName}
+    />
+    <div className={classNames('vads-u-width--full', 'vads-u-margin-top--4')}>
+      {props.apiCategory.apis.map((api: APIDescription) => (
+        <APIReleaseNote flagName={props.apiFlagName} key={api.urlFragment} api={api} />
+      ))}
+    </div>
+  </section>
+);
 
-export const CategoryReleaseNotes = (props: RouteComponentProps<APINameParam>) => {
-  const { apiCategoryKey } = props.match.params;
+export const CategoryReleaseNotes = (): JSX.Element => {
+  const { apiCategoryKey } = useParams<APINameParam>();
   const categoryDefinition = getApiDefinitions()[apiCategoryKey];
   return (
     <ReleaseNotesCollection
@@ -127,13 +125,11 @@ export const CategoryReleaseNotes = (props: RouteComponentProps<APINameParam>) =
   );
 };
 
-export const DeactivatedReleaseNotes = () => {
-  return (
-    <ReleaseNotesCollection
-      categoryKey="deactivated"
-      apiCategory={getDeactivatedCategory()}
-      apiFlagName="enabled"
-      alertText="This is a repository for deactivated APIs and related documentation and release notes."
-    />
-  );
-};
+export const DeactivatedReleaseNotes = () => (
+  <ReleaseNotesCollection
+    categoryKey="deactivated"
+    apiCategory={getDeactivatedCategory()}
+    apiFlagName="enabled"
+    alertText="This is a repository for deactivated APIs and related documentation and release notes."
+  />
+);

--- a/src/containers/releaseNotes/CategoryReleaseNotes.tsx
+++ b/src/containers/releaseNotes/CategoryReleaseNotes.tsx
@@ -62,7 +62,7 @@ const APIReleaseNote = ({
 }: {
   api: APIDescription;
   flagName: 'enabled' | 'hosted_apis';
-}) => {
+}): JSX.Element => {
   const dashUrlFragment = api.urlFragment.replace('_', '-');
 
   return (
@@ -125,7 +125,7 @@ export const CategoryReleaseNotes = (): JSX.Element => {
   );
 };
 
-export const DeactivatedReleaseNotes = () => (
+export const DeactivatedReleaseNotes = (): JSX.Element => (
   <ReleaseNotesCollection
     categoryKey="deactivated"
     apiCategory={getDeactivatedCategory()}


### PR DESCRIPTION
### Description
Jira Ticket: https://vajira.max.gov/browse/API-2912
Category Release Notes pages should now be using a param hook instead of receiving it as a prop.

- [ n/a ] Tests added or updated for change
- [ n/a ] Docs updated
- [ n/a ] Accessibility concerns have been considered and addressed

### Requested feedback
I have a feeling there might be a useLocation use but couldn't 100% nail down if one was needed.
