### PR TITLE
Fix ESLint errors in documentation and refactor SwaggerDocs to use VersionMetadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node scripts/build.js",
     "lint": "./node_modules/.bin/tslint --config tslint.json --project tsconfig.json",
     "lint:ci": "./node_modules/.bin/tslint --config tslint.ci.json --project tsconfig.json -t junit > lint-results.xml",
-    "eslint": "./node_modules/.bin/eslint --ext .ts,.tsx src/actions src/apiDefs src/components/onlyTags src/containers/documentation/swaggerPlugins src/containers/releaseNotes src/containers/support src/reducers",
+    "eslint": "./node_modules/.bin/eslint --ext .ts,.tsx src/actions src/apiDefs src/components/onlyTags src/containers/documentation src/containers/releaseNotes src/containers/support src/reducers",
     "test": "echo You should run test:unit, test:e2e, test:accessibility, or test:visual",
     "test:unit": "node scripts/test.js --projects=unit.jest.config.js",
     "test:unit:ci": "node scripts/test.js --projects=unit.jest.config.js --ci --testResultsProcessor=\"./node_modules/jest-junit-reporter\"",

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -13,7 +13,6 @@ import BetaPage from './containers/Beta';
 import BetaSuccess from './containers/BetaSuccess';
 import DisabledApplyForm from './containers/DisabledApplyForm';
 import DocumentationRoot from './containers/documentation/DocumentationRoot';
-import ProviderIntegrationGuide from './containers/documentation/ProviderIntegrationGuide';
 import Home from './containers/Home';
 import News from './containers/News';
 import NotFound from './containers/NotFound';
@@ -21,6 +20,7 @@ import ReleaseNotes from './containers/releaseNotes/ReleaseNotes';
 import Support from './containers/support/Support';
 import PathToProduction from './content/goLive.mdx';
 import TermsOfService from './content/termsOfService.mdx';
+import ProviderIntegrationGuide from './content/providers/integrationGuide.mdx';
 import { Flag } from './flags';
 
 export function SiteRoutes() {
@@ -58,7 +58,10 @@ export function SiteRoutes() {
       <Route path="/release-notes/:apiCategoryKey?" component={ReleaseNotes} />
       <Route path="/news" component={News} />
       <Route path="/support" component={Support} />
-      <Route path="/providers/integration-guide" component={ProviderIntegrationGuide} />
+      <Route
+        path="/providers/integration-guide"
+        render={() => MarkdownPage(ProviderIntegrationGuide)}
+      />
       <Route component={NotFound} />
     </Switch>
   );

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,5 +1,5 @@
 import { Action, ActionCreator } from 'redux';
-import { APIMetadata } from '../types';
+import { VersionMetadata } from '../types';
 import * as constants from '../types/constants';
 
 export * from './apply';
@@ -11,7 +11,7 @@ export interface SetRequestedAPIVersion extends Action {
 
 export interface SetInitialVersioning extends Action {
   docUrl: string;
-  metadata: APIMetadata;
+  versions: VersionMetadata[];
   type: constants.SET_INITIAL_VERSIONING;
 }
 
@@ -22,9 +22,9 @@ export const setRequstedApiVersion: ActionCreator<SetRequestedAPIVersion> = (ver
 
 export const setInitialVersioning: ActionCreator<SetInitialVersioning> = (
   docUrl: string,
-  metadata: APIMetadata,
+  versions: VersionMetadata[],
 ) => ({
   docUrl,
-  metadata,
   type: constants.SET_INITIAL_VERSIONING,
+  versions,
 });

--- a/src/containers/documentation/ApiDocumentation.test.tsx
+++ b/src/containers/documentation/ApiDocumentation.test.tsx
@@ -11,6 +11,7 @@ import { AppFlags, FlagsProvider } from '../../flags';
 import store, { history } from '../../store';
 import ApiDocumentation from './ApiDocumentation';
 
+const ReleaseNotes: React.FunctionComponent = () => <div>My API&apos;s release notes</div>;
 const api: APIDescription = {
   description: "it's a great API!",
   docSources: [
@@ -20,7 +21,7 @@ const api: APIDescription = {
   ],
   enabledByDefault: true,
   name: 'My API',
-  releaseNotes: () => <div>My API's release notes</div>,
+  releaseNotes: ReleaseNotes,
   trustedPartnerOnly: false,
   urlFragment: 'my_api',
   vaInternalOnly: false,
@@ -29,9 +30,8 @@ const api: APIDescription = {
 const server = setupServer(
   rest.get(
     'https://example.com/my/openapi/spec',
-    (req: MockedRequest, res: ResponseComposition, context: typeof restContext): MockedResponse => {
-      return res(context.status(200), context.json(openAPIData));
-    },
+    (req: MockedRequest, res: ResponseComposition, context: typeof restContext): MockedResponse =>
+      res(context.status(200), context.json(openAPIData)),
   ),
 );
 
@@ -73,7 +73,7 @@ describe('ApiDocumentation', () => {
       const tagEl: HTMLElement = await screen.findByRole('heading', { name: tag });
       expect(tagEl.tagName.toLowerCase()).toBe('h3');
       expect(tagEl.nextElementSibling).not.toBeNull();
-      return tagEl.nextElementSibling! as HTMLElement;
+      return tagEl.nextElementSibling as HTMLElement;
     };
 
     it('has a section for each operation', async () => {

--- a/src/containers/documentation/DocumentationRoot.e2e.ts
+++ b/src/containers/documentation/DocumentationRoot.e2e.ts
@@ -5,13 +5,13 @@ import { puppeteerHost } from '../../e2eHelpers';
 describe('position sticky', () => {
   it('should keep nav element in place after scroll', async () => {
     await page.goto(`${puppeteerHost}/explore`, { waitUntil: 'networkidle0', timeout: 60000 });
-    const originalDistanceFromTop = await page.evaluate(() => {
-      return document.querySelectorAll('.va-api-side-nav')[0].getBoundingClientRect().top;
-    });
+    const originalDistanceFromTop = await page.evaluate(
+      () => document.querySelectorAll('.va-api-side-nav')[0].getBoundingClientRect().top,
+    );
     await page.evaluate(() => window.scrollBy(0, 585)); // scroll 585px
-    const distanceFromTop = await page.evaluate(() => {
-      return document.querySelectorAll('.va-api-side-nav')[0].getBoundingClientRect().top;
-    });
+    const distanceFromTop = await page.evaluate(
+      () => document.querySelectorAll('.va-api-side-nav')[0].getBoundingClientRect().top,
+    );
     expect(distanceFromTop).toEqual(20);
     expect(distanceFromTop).not.toEqual(originalDistanceFromTop);
   });
@@ -20,7 +20,7 @@ describe('position sticky', () => {
     const waitScrollClick = async (selector: string) => {
       await page.waitForSelector(selector, { visible: true });
       await page.evaluate(sel => {
-        const elem = document.querySelector(sel);
+        const elem = document.querySelector(sel) as HTMLElement;
         if (elem) {
           elem.scrollIntoView();
         }
@@ -65,9 +65,7 @@ describe('position sticky', () => {
     });
     await clickCard('Health API');
     await clickCard('Authorization');
-    const haloText = await page.$eval('.header-halo', elem => {
-      return elem.textContent;
-    });
+    const haloText = await page.$eval('.header-halo', elem => elem.textContent);
     expect(haloText).toEqual('Health API');
   });
 });

--- a/src/containers/documentation/ProviderIntegrationGuide.tsx
+++ b/src/containers/documentation/ProviderIntegrationGuide.tsx
@@ -1,8 +1,0 @@
-import MarkdownPage from '../../components/MarkdownPage';
-
-import IntegrationGuideContent from '../../content/providers/integrationGuide.mdx';
-
-export default function ProviderIntegrationGuide(): JSX.Element {
-  return MarkdownPage(IntegrationGuideContent);
-}
-

--- a/src/containers/documentation/SwaggerDocs.tsx
+++ b/src/containers/documentation/SwaggerDocs.tsx
@@ -25,14 +25,6 @@ export interface SwaggerDocsProps {
   versionNumber: string;
 }
 
-export interface VersionInfo {
-  version: string;
-  status: string;
-  path: string;
-  healthcheck: string;
-  internal_only: boolean;
-}
-
 const mapStateToProps = (state: RootState) => ({
   docUrl: getDocURL(state.apiVersioning),
   location: state.router.location,

--- a/src/containers/documentation/swaggerPlugins/ExtendedLayout.tsx
+++ b/src/containers/documentation/swaggerPlugins/ExtendedLayout.tsx
@@ -15,13 +15,11 @@ const ExtendedLayout: React.FunctionComponent<ExtendedLayoutProps> = (
   props: ExtendedLayoutProps,
 ): JSX.Element => {
   const { getComponent, getSystem } = props;
-  const apiMetadata = getSystem().versionSelectors.apiMetadata();
+  const versions = getSystem().versionSelectors.versionMetadata();
   const BaseLayout = getComponent('BaseLayout', true);
   return (
     <div>
-      {apiMetadata && apiMetadata.meta.versions.length > 1 && (
-        <VersionSelect getSystem={getSystem} />
-      )}
+      {versions && versions.length > 1 && <VersionSelect getSystem={getSystem} />}
       <BaseLayout />
     </div>
   );

--- a/src/containers/documentation/swaggerPlugins/VersionActions.ts
+++ b/src/containers/documentation/swaggerPlugins/VersionActions.ts
@@ -1,17 +1,17 @@
-import { APIMetadata } from '../../../types';
+import { VersionMetadata } from '../../../types';
 import { SwaggerVersionActions } from './types';
 
 export const VersionActions = (
   updateVersionHandler: (newVersion: string) => void,
 ): SwaggerVersionActions => ({
   actions: {
-    setApiMetadata: (metadata: APIMetadata) => ({
-      payload: metadata,
-      type: 'API_METADATA_SET',
-    }),
     setApiVersion: (version: string) => ({
       payload: version,
       type: 'API_VERSION_SET',
+    }),
+    setVersionMetadata: (metadata: VersionMetadata[]) => ({
+      payload: metadata,
+      type: 'VERSION_METADATA_SET',
     }),
     updateVersion: (version: string) => {
       updateVersionHandler(version);

--- a/src/containers/documentation/swaggerPlugins/VersionReducers.ts
+++ b/src/containers/documentation/swaggerPlugins/VersionReducers.ts
@@ -1,15 +1,15 @@
 import { Map } from 'immutable';
-import { SetAPIMetadataAction, SetAPIVersionAction, SwaggerVersionReducers } from './types';
+import { SetVersionMetadataAction, SetAPIVersionAction, SwaggerVersionReducers } from './types';
 
 export const VersionReducers: SwaggerVersionReducers = {
   reducers: {
-    API_METADATA_SET: (
-      state: Map<string, unknown>,
-      action: SetAPIMetadataAction,
-    ): Map<string, unknown> => state.set('apiMetadata', action.payload),
     API_VERSION_SET: (
       state: Map<string, unknown>,
       action: SetAPIVersionAction,
     ): Map<string, unknown> => state.set('apiVersion', action.payload),
+    VERSION_METADATA_SET: (
+      state: Map<string, unknown>,
+      action: SetVersionMetadataAction,
+    ): Map<string, unknown> => state.set('versionMetadata', action.payload),
   },
 };

--- a/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
+++ b/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { IVersionInfo } from '../SwaggerDocs';
+import { VersionInfo } from '../SwaggerDocs';
 import { System } from './types';
 
 export interface VersionSelectProps {
@@ -21,7 +21,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
 
   public getCurrentVersion(): string {
     const metadata = this.props.getSystem().versionSelectors.apiMetadata();
-    const selectCurrentVersion = (versionInfo: IVersionInfo) =>
+    const selectCurrentVersion = (versionInfo: VersionInfo) =>
       versionInfo.status === 'Current Version';
 
     // if this component is rendered, there should (a) be versions present in metadata and (b) 
@@ -38,7 +38,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
     this.props.getSystem().versionActions.updateVersion(this.state.version);
   }
 
-  public buildDisplay(metaObject: IVersionInfo): string {
+  public buildDisplay(metaObject: VersionInfo): string {
     const { version, status, internal_only } = metaObject;
     return `${version} - ${status} ${internal_only ? '(Internal Only)' : ''}`;
   }
@@ -66,7 +66,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
           {this.props
             .getSystem()
             .versionSelectors.apiMetadata()
-            .meta.versions.map((versionInfo: IVersionInfo) =>(
+            .meta.versions.map((versionInfo: VersionInfo) =>(
               <option value={versionInfo.version} key={versionInfo.version}>
                 {this.buildDisplay(versionInfo)}
               </option>

--- a/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
+++ b/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { VersionInfo } from '../SwaggerDocs';
+import { VersionMetadata } from '../../../types';
 import { System } from './types';
 
 export interface VersionSelectProps {
@@ -21,7 +21,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
 
   public getCurrentVersion(): string {
     const metadata = this.props.getSystem().versionSelectors.apiMetadata();
-    const selectCurrentVersion = (versionInfo: VersionInfo) =>
+    const selectCurrentVersion = (versionInfo: VersionMetadata) =>
       versionInfo.status === 'Current Version';
 
     // if this component is rendered, there should (a) be versions present in metadata and (b) 
@@ -38,7 +38,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
     this.props.getSystem().versionActions.updateVersion(this.state.version);
   }
 
-  public buildDisplay(metaObject: VersionInfo): string {
+  public buildDisplay(metaObject: VersionMetadata): string {
     const { version, status, internal_only } = metaObject;
     return `${version} - ${status} ${internal_only ? '(Internal Only)' : ''}`;
   }
@@ -66,7 +66,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
           {this.props
             .getSystem()
             .versionSelectors.apiMetadata()
-            .meta.versions.map((versionInfo: VersionInfo) =>(
+            .meta.versions.map((versionInfo: VersionMetadata) =>(
               <option value={versionInfo.version} key={versionInfo.version}>
                 {this.buildDisplay(versionInfo)}
               </option>

--- a/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
+++ b/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
@@ -20,14 +20,14 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
   }
 
   public getCurrentVersion(): string {
-    const metadata = this.props.getSystem().versionSelectors.apiMetadata();
+    const versions = this.props.getSystem().versionSelectors.versionMetadata();
     const selectCurrentVersion = (versionInfo: VersionMetadata) =>
       versionInfo.status === 'Current Version';
 
     // if this component is rendered, there should (a) be versions present in metadata and (b) 
     // be a version with the status "Current Version". as a fallback, though, we set it to the 
     // empty string as in getVersionNumber() in src/reducers/api-versioning.ts.
-    return metadata.meta.versions.find(selectCurrentVersion)?.version || '';
+    return versions.find(selectCurrentVersion)?.version || '';
   }
 
   public handleSelectChange(version: string): void {
@@ -65,8 +65,8 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
         >
           {this.props
             .getSystem()
-            .versionSelectors.apiMetadata()
-            .meta.versions.map((versionInfo: VersionMetadata) =>(
+            .versionSelectors.versionMetadata()
+            .map((versionInfo: VersionMetadata) =>(
               <option value={versionInfo.version} key={versionInfo.version}>
                 {this.buildDisplay(versionInfo)}
               </option>

--- a/src/containers/documentation/swaggerPlugins/VersionSelector.ts
+++ b/src/containers/documentation/swaggerPlugins/VersionSelector.ts
@@ -1,17 +1,17 @@
 import { Map } from 'immutable';
 import { createSelector } from 'reselect';
-import { APIMetadata } from '../../../types';
+import { VersionMetadata } from '../../../types';
 
 const apiVersion = (state: Map<string, unknown>): string => state.get('apiVersion') as string;
 export const VersionSelector = {
   selectors: {
-    apiMetadata: (state: Map<string, unknown>): APIMetadata =>
-      state.get('apiMetadata') as APIMetadata,
     apiName: (state: Map<string, unknown>): string => state.get('apiName') as string,
     apiVersion: (state: Map<string, unknown>): string => state.get('apiVersion') as string,
     majorVersion: createSelector(
       apiVersion,
       (version: string): string => (version ? version.substring(0, 1) : '0'),
     ),
+    versionMetadata: (state: Map<string, unknown>): VersionMetadata[] =>
+      state.get('versionMetadata') as VersionMetadata[],
   },
 };

--- a/src/containers/documentation/swaggerPlugins/types.ts
+++ b/src/containers/documentation/swaggerPlugins/types.ts
@@ -2,7 +2,7 @@ import { Map, OrderedMap } from 'immutable';
 import { RequestOptions, SwaggerMapValues } from 'swagger-client';
 import { System as BaseSystem } from 'swagger-ui';
 import { OutputSelector } from 'reselect';
-import { APIMetadata } from '../../../types';
+import { VersionMetadata } from '../../../types';
 
 /**
  * COMPONENT PLUGINS
@@ -15,8 +15,8 @@ export interface ParametersProps {
 /**
  * ACTION PLUGINS
  */
-export interface SetAPIMetadataAction {
-  payload: APIMetadata;
+export interface SetVersionMetadataAction {
+  payload: VersionMetadata[];
   type: string;
 }
 
@@ -31,7 +31,7 @@ interface UpdateVersionAction {
 
 export interface SwaggerVersionActions {
   actions: {
-    setApiMetadata: (metadata: APIMetadata) => SetAPIMetadataAction;
+    setVersionMetadata: (metadata: VersionMetadata[]) => SetVersionMetadataAction;
     setApiVersion: (version: string) => SetAPIVersionAction;
     updateVersion: (version: string) => UpdateVersionAction;
   };
@@ -47,9 +47,9 @@ export interface SwaggerVersionReducers {
       action: SetAPIVersionAction,
     ) => Map<string, unknown>;
 
-    API_METADATA_SET: (
+    VERSION_METADATA_SET: (
       state: Map<string, unknown>,
-      action: SetAPIMetadataAction,
+      action: SetVersionMetadataAction,
     ) => Map<string, unknown>;
   };
 }
@@ -59,7 +59,7 @@ export interface SwaggerVersionReducers {
  */
 export interface SwaggerVersionSelectors {
   selectors: {
-    apiMetadata: (state: Map<string, unknown>) => APIMetadata;
+    versionMetadata: (state: Map<string, unknown>) => VersionMetadata[];
     apiName: (state: Map<string, unknown>) => string;
     apiVersion: (state: Map<string, unknown>) => string;
     majorVersion: OutputSelector<Map<string, unknown>, string, (result: string) => string>;
@@ -98,13 +98,13 @@ export interface SwaggerPlugins {
 export interface System extends BaseSystem {
   versionActions: {
     setApiVersion: (version: string) => void;
-    setApiMetadata: (meta: APIMetadata) => void;
+    setVersionMetadata: (meta: VersionMetadata[]) => void;
     updateVersion: (version: string) => void;
   };
 
   versionSelectors: {
     majorVersion: () => string;
-    apiMetadata: () => APIMetadata;
+    versionMetadata: () => VersionMetadata[];
     apiVersion: () => string;
   };
 }

--- a/src/reducers/api-versioning.spec.ts
+++ b/src/reducers/api-versioning.spec.ts
@@ -6,8 +6,8 @@ describe('get doc url', () => {
   it('should return initial doc url when no metadata', () => {
     const state: APIVersioning = {
       docUrl: 'http://google.com',
-      metadata: null,
       requestedApiVersion: '1.0.0',
+      versions: null,
     };
 
     expect(getDocURL(state)).toEqual('http://google.com');
@@ -16,20 +16,16 @@ describe('get doc url', () => {
   it('should return specified doc url when metadata is present', () => {
     const state: APIVersioning = {
       docUrl: 'http://google.com',
-      metadata: {
-        meta: {
-          versions: [
-            {
-              healthcheck: 'healthcheck',
-              internal_only: false,
-              path: 'mypath',
-              status: 'Current Version',
-              version: '1.0.0',
-            },
-          ],
-        },
-      },
       requestedApiVersion: '1.0.0',
+      versions: [
+        {
+          healthcheck: 'healthcheck',
+          internal_only: false,
+          path: 'mypath',
+          status: 'Current Version',
+          version: '1.0.0',
+        },
+      ],
     };
 
     expect(getDocURL(state)).toEqual(expect.stringContaining('mypath'));
@@ -40,8 +36,8 @@ describe('get version', () => {
   it("should return 'current' when metadata is not present", () => {
     const state: APIVersioning = {
       docUrl: 'http://google.com',
-      metadata: null,
       requestedApiVersion: '1.0.0',
+      versions: null,
     };
 
     expect(getVersion(state)).toEqual('current');
@@ -50,20 +46,16 @@ describe('get version', () => {
   it("should return 'current' when metadata is present and version is current version", () => {
     const state: APIVersioning = {
       docUrl: 'http://google.com',
-      metadata: {
-        meta: {
-          versions: [
-            {
-              healthcheck: 'healthcheck',
-              internal_only: false,
-              path: 'mypath',
-              status: 'Current Version',
-              version: '1.0.0',
-            },
-          ],
-        },
-      },
       requestedApiVersion: '1.0.0',
+      versions: [
+        {
+          healthcheck: 'healthcheck',
+          internal_only: false,
+          path: 'mypath',
+          status: 'Current Version',
+          version: '1.0.0',
+        },
+      ],
     };
 
     expect(getVersion(state)).toEqual('current');
@@ -72,20 +64,16 @@ describe('get version', () => {
   it('should return the version when metadata is present and version is not the current version', () => {
     const state: APIVersioning = {
       docUrl: 'http://google.com',
-      metadata: {
-        meta: {
-          versions: [
-            {
-              healthcheck: 'healthcheck',
-              internal_only: false,
-              path: 'mypath',
-              status: 'Previous Version',
-              version: '1.0.0',
-            },
-          ],
-        },
-      },
       requestedApiVersion: '1.0.0',
+      versions: [
+        {
+          healthcheck: 'healthcheck',
+          internal_only: false,
+          path: 'mypath',
+          status: 'Previous Version',
+          version: '1.0.0',
+        },
+      ],
     };
 
     expect(getVersion(state)).toEqual('1.0.0');

--- a/src/reducers/api-versioning.ts
+++ b/src/reducers/api-versioning.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { SetInitialVersioning, SetRequestedAPIVersion } from '../actions';
-import { IVersionInfo } from '../containers/documentation/SwaggerDocs';
+import { VersionInfo } from '../containers/documentation/SwaggerDocs';
 import { APIMetadata, APIVersioning } from '../types';
 import * as constants from '../types/constants';
 
@@ -21,11 +21,11 @@ const getVersionInfo = createSelector(
       metadata &&
       (!requestedVersion || requestedVersion === constants.CURRENT_VERSION_IDENTIFIER)
     ) {
-      const selectCurrentVersion = (versionInfo: IVersionInfo) =>
+      const selectCurrentVersion = (versionInfo: VersionInfo) =>
         versionInfo.status === currentVersionStatus;
       return metadata.meta.versions.find(selectCurrentVersion);
     } else {
-      const selectSpecificVersion = (versionInfo: IVersionInfo) =>
+      const selectSpecificVersion = (versionInfo: VersionInfo) =>
         versionInfo.version === requestedVersion;
       return metadata.meta.versions.find(selectSpecificVersion);
     }
@@ -35,7 +35,7 @@ const getVersionInfo = createSelector(
 export const getDocURL = createSelector(
   getVersionInfo,
   getInitialDocURL,
-  (versionInfo: IVersionInfo, initialDocUrl: string) => {
+  (versionInfo: VersionInfo, initialDocUrl: string) => {
     if (!versionInfo) {
       return initialDocUrl;
     }
@@ -45,7 +45,7 @@ export const getDocURL = createSelector(
 
 export const getVersion = createSelector(
   getVersionInfo,
-  (versionInfo: IVersionInfo) => {
+  (versionInfo: VersionInfo) => {
     if (!versionInfo) {
       return constants.CURRENT_VERSION_IDENTIFIER;
     }
@@ -57,7 +57,7 @@ export const getVersion = createSelector(
 
 export const getVersionNumber = createSelector(
   getVersionInfo,
-  (versionInfo: IVersionInfo) => {
+  (versionInfo: VersionInfo) => {
     if (!versionInfo) {
       return '';
     }

--- a/src/reducers/api-versioning.ts
+++ b/src/reducers/api-versioning.ts
@@ -1,32 +1,32 @@
 import { createSelector } from 'reselect';
 import { SetInitialVersioning, SetRequestedAPIVersion } from '../actions';
-import { APIMetadata, APIVersioning, VersionMetadata } from '../types';
+import { APIVersioning, VersionMetadata } from '../types';
 import * as constants from '../types/constants';
 
 const currentVersionStatus = 'Current Version';
 const getRequestedApiVersion = (state: APIVersioning) => state.requestedApiVersion;
-const getMetadata = (state: APIVersioning) => state.metadata;
+const getAPIVersions = (state: APIVersioning) => state.versions;
 const getInitialDocURL = (state: APIVersioning) => state.docUrl;
 
 const getVersionInfo = createSelector(
   getRequestedApiVersion,
-  getMetadata,
-  (requestedVersion: string, metadata: APIMetadata) => {
-    if (!metadata) {
+  getAPIVersions,
+  (requestedVersion: string, versionMetadata: VersionMetadata[]) => {
+    if (!versionMetadata) {
       return null;
     }
 
     if (
-      metadata &&
+      versionMetadata &&
       (!requestedVersion || requestedVersion === constants.CURRENT_VERSION_IDENTIFIER)
     ) {
       const selectCurrentVersion = (versionInfo: VersionMetadata) =>
         versionInfo.status === currentVersionStatus;
-      return metadata.meta.versions.find(selectCurrentVersion);
+      return versionMetadata.find(selectCurrentVersion);
     } else {
       const selectSpecificVersion = (versionInfo: VersionMetadata) =>
         versionInfo.version === requestedVersion;
-      return metadata.meta.versions.find(selectSpecificVersion);
+      return versionMetadata.find(selectSpecificVersion);
     }
   },
 );
@@ -67,8 +67,8 @@ export const getVersionNumber = createSelector(
 export const apiVersioning = (
   state = {
     docUrl: '',
-    metadata: null,
     requestedApiVersion: constants.CURRENT_VERSION_IDENTIFIER,
+    versions: null,
   },
   action: SetInitialVersioning | SetRequestedAPIVersion,
 ): APIVersioning => {
@@ -76,7 +76,7 @@ export const apiVersioning = (
     case constants.SET_REQUESTED_API_VERSION:
       return { ...state, requestedApiVersion: action.version };
     case constants.SET_INITIAL_VERSIONING:
-      return { ...state, metadata: action.metadata, docUrl: action.docUrl };
+      return { ...state, versions: action.versions, docUrl: action.docUrl };
     default:
       return state;
   }

--- a/src/reducers/api-versioning.ts
+++ b/src/reducers/api-versioning.ts
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 import { SetInitialVersioning, SetRequestedAPIVersion } from '../actions';
-import { VersionInfo } from '../containers/documentation/SwaggerDocs';
-import { APIMetadata, APIVersioning } from '../types';
+import { APIMetadata, APIVersioning, VersionMetadata } from '../types';
 import * as constants from '../types/constants';
 
 const currentVersionStatus = 'Current Version';
@@ -21,11 +20,11 @@ const getVersionInfo = createSelector(
       metadata &&
       (!requestedVersion || requestedVersion === constants.CURRENT_VERSION_IDENTIFIER)
     ) {
-      const selectCurrentVersion = (versionInfo: VersionInfo) =>
+      const selectCurrentVersion = (versionInfo: VersionMetadata) =>
         versionInfo.status === currentVersionStatus;
       return metadata.meta.versions.find(selectCurrentVersion);
     } else {
-      const selectSpecificVersion = (versionInfo: VersionInfo) =>
+      const selectSpecificVersion = (versionInfo: VersionMetadata) =>
         versionInfo.version === requestedVersion;
       return metadata.meta.versions.find(selectSpecificVersion);
     }
@@ -35,7 +34,7 @@ const getVersionInfo = createSelector(
 export const getDocURL = createSelector(
   getVersionInfo,
   getInitialDocURL,
-  (versionInfo: VersionInfo, initialDocUrl: string) => {
+  (versionInfo: VersionMetadata, initialDocUrl: string) => {
     if (!versionInfo) {
       return initialDocUrl;
     }
@@ -45,7 +44,7 @@ export const getDocURL = createSelector(
 
 export const getVersion = createSelector(
   getVersionInfo,
-  (versionInfo: VersionInfo) => {
+  (versionInfo: VersionMetadata) => {
     if (!versionInfo) {
       return constants.CURRENT_VERSION_IDENTIFIER;
     }
@@ -57,7 +56,7 @@ export const getVersion = createSelector(
 
 export const getVersionNumber = createSelector(
   getVersionInfo,
-  (versionInfo: VersionInfo) => {
+  (versionInfo: VersionMetadata) => {
     if (!versionInfo) {
       return '';
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,7 @@ export interface APIMetadata {
 
 export interface APIVersioning {
   docUrl: string;
-  metadata: APIMetadata | null;
+  versions: VersionMetadata[] | null;
   requestedApiVersion: string;
 }
 


### PR DESCRIPTION
### Description
<!-- 
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

fixes ESLint errors in `src/containers/documentation` for [API-1323](https://vajira.max.gov/browse/API-1323). also spawned some refactoring, which included

- removing the `IVersionInfo` interface from `SwaggerDocs` and replacing it with the `VersionMetadata` interface from `src/types/index`, since the two interfaces are identical and the types directory is a more appropriate place for a shared interface.
- refactoring the handling of version metadata to remove some unnecessary nesting that the developer portal doesn't care about. previously, we would take the whole `APIMetadata` object and pass it around `SwaggerDocs`, the Redux state, and Swagger UI plugins, but really, we only care about `APIMetadata.meta.versions`. so i took the response body from the metadata request, extracted the versions array at that point, and updated every subsequent place that it's used to refer to a versions array rather than the whole metadata object.
- deleting `ProviderIntegrationGuide` and inlining it in `Routes` instead. didn't really need its own file.

### Process
<!-- 
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation 
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them. 
-->
- [ ] Tests added or updated for change
  - used tests for regression checks
- [n/a] Docs updated
- [n/a] Accessibility concerns have been considered and addressed

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
