### PR TITLE
DRAFT: API-2540 - migrate SwaggerDocs to function component/hooks [HELP NEEDED]

### DIFF
--- a/src/containers/documentation/ApiDocumentation.tsx
+++ b/src/containers/documentation/ApiDocumentation.tsx
@@ -7,7 +7,7 @@ import * as actions from '../../actions';
 import { APIDescription, ApiDescriptionPropType, APIDocSource } from '../../apiDefs/schema';
 import { Flag } from '../../flags';
 import { history } from '../../store';
-import SwaggerDocs from './SwaggerDocs';
+import { SwaggerDocs } from './SwaggerDocs';
 
 import '../../../node_modules/react-tabs/style/react-tabs.scss';
 

--- a/src/containers/documentation/SwaggerDocs.tsx
+++ b/src/containers/documentation/SwaggerDocs.tsx
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/browser';
+import { History } from 'history';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
-import { usePrevious } from 'src/hooks/previous/Previous';
 import SwaggerUI from 'swagger-ui';
+import { usePrevious } from '../../hooks';
 import * as actions from '../../actions';
 import { APIDocSource } from '../../apiDefs/schema';
 import { getDocURL, getVersion, getVersionNumber } from '../../reducers/api-versioning';
@@ -25,6 +26,52 @@ export interface VersionInfo {
   internal_only: boolean;
 }
 
+const getMetadata = async (metadataUrl?: string): Promise<APIMetadata | null> => {
+  if (!metadataUrl) {
+    return null;
+  }
+  try {
+    const request = new Request(`${metadataUrl}`, {
+      method: 'GET',
+    });
+    const response = await fetch(request);
+    return response.json() as Promise<APIMetadata>;
+  } catch (error) {
+    Sentry.captureException(error);
+    return null;
+  }
+};
+
+const setSearchParam = (history: History, queryString: string, version: string) => {
+  const params = new URLSearchParams(queryString);
+  if (params.get('version') !== version) {
+    params.set('version', version);
+    history.push(`${history.location.pathname}?${params.toString()}`);
+  }
+};
+
+const renderSwaggerUI = (
+  dispatch: React.Dispatch<actions.SetRequestedAPIVersion>,
+  docUrl: string,
+  versionNumber: string,
+  metadata: APIMetadata | null,
+) => {
+  const handleVersionChange = (requestedVersion: string) => {
+    dispatch(actions.setRequstedApiVersion(requestedVersion));
+  };
+  if (document.getElementById('swagger-ui') && docUrl.length !== 0) {
+    const plugins = SwaggerPlugins(handleVersionChange);
+    const ui: System = SwaggerUI({
+      dom_id: '#swagger-ui',
+      layout: 'ExtendedLayout',
+      plugins: [plugins],
+      url: docUrl,
+    }) as System;
+    ui.versionActions.setApiVersion(versionNumber);
+    ui.versionActions.setApiMetadata(metadata as APIMetadata);
+  }
+};
+
 const SwaggerDocs = (props: SwaggerDocsProps): JSX.Element => {
   const dispatch: React.Dispatch<
     actions.SetRequestedAPIVersion | actions.SetInitialVersioning
@@ -37,92 +84,46 @@ const SwaggerDocs = (props: SwaggerDocsProps): JSX.Element => {
 
   const history = useHistory();
   const location = useLocation();
-  const prevApiName = usePrevious(props.apiName);
+
+  const { apiName } = props;
+
+  const prevApiName = usePrevious(apiName);
   const prevVersion = usePrevious(version);
 
-  const setSearchParam = React.useCallback(() => {
-    const params = new URLSearchParams(location.search);
-    if (params.get('version') !== version) {
-      console.log('setSearchParam()');
-      params.set('version', version);
-      history.push(`${history.location.pathname}?${params.toString()}`);
-    }
-  }, [history, location.search, version]);
+  const { openApiUrl, metadataUrl } = props.docSource;
 
-  const setMetadataAndDocUrl = React.useCallback(async () => {
-    const { openApiUrl, metadataUrl } = props.docSource;
-    const currentMetadata = (await getMetadata(metadataUrl)) as string | undefined;
+  const setMetadataAndDocUrl = async () => {
+    const currentMetadata = await getMetadata(metadataUrl);
 
     dispatch(actions.setInitialVersioning(openApiUrl, currentMetadata));
-  }, [dispatch, props.docSource]);
-
-  const getMetadata = async (metadataUrl?: string): Promise<any> => {
-    if (!metadataUrl) {
-      return null;
-    }
-    try {
-      const request = new Request(`${metadataUrl}`, {
-        method: 'GET',
-      });
-      const response = await fetch(request);
-      return response.json();
-    } catch (error) {
-      Sentry.captureException(error);
-      return null;
-    }
   };
 
-  const renderSwaggerUI = React.useCallback(() => {
-    const handleVersionChange = (currentVersion: string) => {
-      dispatch(actions.setRequstedApiVersion(currentVersion));
-      setSearchParam();
-    };
-    if (document.getElementById('swagger-ui') && docUrl.length !== 0) {
-      console.log('renderSwaggerUI()');
-      const plugins = SwaggerPlugins(handleVersionChange);
-      const ui: System = SwaggerUI({
-        dom_id: '#swagger-ui',
-        layout: 'ExtendedLayout',
-        plugins: [plugins],
-        url: docUrl,
-      }) as System;
-      ui.versionActions.setApiVersion(versionNumber);
-      ui.versionActions.setApiMetadata(metadata as APIMetadata);
-    }
-  }, [dispatch, docUrl, metadata, setSearchParam, versionNumber]);
-
-  const setupAndRenderSwaggerUI = React.useCallback(async () => {
-    await setMetadataAndDocUrl();
-    setSearchParam();
-    renderSwaggerUI();
-  }, [renderSwaggerUI, setMetadataAndDocUrl, setSearchParam]);
+  if (prevApiName !== apiName) {
+    void setMetadataAndDocUrl();
+  }
 
   /**
-   * componentDidMount()
+   * Clear state on unmount
    */
-  React.useLayoutEffect(() => {
-    void setupAndRenderSwaggerUI();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  React.useEffect(
+    () => () => {
+      dispatch(actions.setInitialVersioning('', null));
+    },
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
-  /**
-   * componentDidUpdate()
-   */
-  React.useLayoutEffect(() => {
-    if (prevApiName !== props.apiName) {
-      void setupAndRenderSwaggerUI();
-    } else if (prevVersion !== version) {
-      setSearchParam();
-      renderSwaggerUI();
+  React.useEffect(() => {
+    let navigating = false;
+
+    if (prevVersion !== version) {
+      navigating = true;
+      setSearchParam(history, location.search, version);
     }
-  }, [
-    prevApiName,
-    prevVersion,
-    props.apiName,
-    renderSwaggerUI,
-    setSearchParam,
-    setupAndRenderSwaggerUI,
-    version,
-  ]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    if (!navigating) {
+      renderSwaggerUI(dispatch, docUrl, versionNumber, metadata);
+    }
+  }, [dispatch, docUrl, history, location.search, prevVersion, version, versionNumber, metadata]);
 
   const { apiIntro } = props.docSource;
 

--- a/src/containers/documentation/SwaggerDocs.tsx
+++ b/src/containers/documentation/SwaggerDocs.tsx
@@ -13,7 +13,7 @@ import { SwaggerPlugins, System } from './swaggerPlugins';
 
 import 'swagger-ui-themes/themes/3.x/theme-muted.css';
 
-export interface ISwaggerDocsProps {
+export interface SwaggerDocsProps {
   apiName: string;
   docSource: APIDocSource;
   docUrl: string;
@@ -23,9 +23,9 @@ export interface ISwaggerDocsProps {
   setRequestedApiVersion: (version: string) => void;
   version: string;
   versionNumber: string;
-}
+} 
 
-export interface IVersionInfo {
+export interface VersionInfo {
   version: string;
   status: string;
   path: string;
@@ -56,14 +56,14 @@ const mapDispatchToProps = (
   };
 };
 
-class SwaggerDocs extends React.Component<ISwaggerDocsProps> {
+class SwaggerDocs extends React.Component<SwaggerDocsProps> {
   public async componentDidMount() {
     await this.setMetadataAndDocUrl();
     this.setSearchParam();
     this.renderSwaggerUI();
   }
 
-  public async componentDidUpdate(prevProps: ISwaggerDocsProps) {
+  public async componentDidUpdate(prevProps: SwaggerDocsProps) {
     if (prevProps.apiName !== this.props.apiName) {
       await this.setMetadataAndDocUrl();
       this.setSearchParam();

--- a/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
+++ b/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { IVersionInfo } from '../SwaggerDocs';
+import { VersionInfo } from '../SwaggerDocs';
 import { System } from './types';
 
 export interface VersionSelectProps {
@@ -21,7 +21,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
 
   public getCurrentVersion(): string {
     const metadata = this.props.getSystem().versionSelectors.apiMetadata();
-    const selectCurrentVersion = (versionInfo: IVersionInfo) =>
+    const selectCurrentVersion = (versionInfo: VersionInfo) =>
       versionInfo.status === 'Current Version';
 
     // if this component is rendered, there should (a) be versions present in metadata and (b) 
@@ -38,7 +38,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
     this.props.getSystem().versionActions.updateVersion(this.state.version);
   }
 
-  public buildDisplay(metaObject: IVersionInfo): string {
+  public buildDisplay(metaObject: VersionInfo): string {
     const { version, status, internal_only } = metaObject;
     return `${version} - ${status} ${internal_only ? '(Internal Only)' : ''}`;
   }
@@ -66,7 +66,7 @@ export default class VersionSelect extends React.Component<VersionSelectProps, V
           {this.props
             .getSystem()
             .versionSelectors.apiMetadata()
-            .meta.versions.map((versionInfo: IVersionInfo) =>(
+            .meta.versions.map((versionInfo: VersionInfo) =>(
               <option value={versionInfo.version} key={versionInfo.version}>
                 {this.buildDisplay(versionInfo)}
               </option>

--- a/src/reducers/api-versioning.ts
+++ b/src/reducers/api-versioning.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { SetInitialVersioning, SetRequestedAPIVersion } from '../actions';
-import { IVersionInfo } from '../containers/documentation/SwaggerDocs';
+import { VersionInfo } from '../containers/documentation/SwaggerDocs';
 import { APIMetadata, APIVersioning } from '../types';
 import * as constants from '../types/constants';
 
@@ -21,11 +21,11 @@ const getVersionInfo = createSelector(
       metadata &&
       (!requestedVersion || requestedVersion === constants.CURRENT_VERSION_IDENTIFIER)
     ) {
-      const selectCurrentVersion = (versionInfo: IVersionInfo) =>
+      const selectCurrentVersion = (versionInfo: VersionInfo) =>
         versionInfo.status === currentVersionStatus;
       return metadata.meta.versions.find(selectCurrentVersion);
     } else {
-      const selectSpecificVersion = (versionInfo: IVersionInfo) =>
+      const selectSpecificVersion = (versionInfo: VersionInfo) =>
         versionInfo.version === requestedVersion;
       return metadata.meta.versions.find(selectSpecificVersion);
     }
@@ -35,7 +35,7 @@ const getVersionInfo = createSelector(
 export const getDocURL = createSelector(
   getVersionInfo,
   getInitialDocURL,
-  (versionInfo: IVersionInfo, initialDocUrl: string) => {
+  (versionInfo: VersionInfo, initialDocUrl: string) => {
     if (!versionInfo) {
       return initialDocUrl;
     }
@@ -45,7 +45,7 @@ export const getDocURL = createSelector(
 
 export const getVersion = createSelector(
   getVersionInfo,
-  (versionInfo: IVersionInfo) => {
+  (versionInfo: VersionInfo) => {
     if (!versionInfo) {
       return constants.CURRENT_VERSION_IDENTIFIER;
     }
@@ -57,7 +57,7 @@ export const getVersion = createSelector(
 
 export const getVersionNumber = createSelector(
   getVersionInfo,
-  (versionInfo: IVersionInfo) => {
+  (versionInfo: VersionInfo) => {
     if (!versionInfo) {
       return '';
     }


### PR DESCRIPTION
### Description
Migrating the `SwaggerDocs` container from class to functional component using hooks.

Currently not working:
- I believe one of the main issues is that the "`componentDidMount()`" replacement uses stale values even though they are updated. `setMetadataAndDocUrl()` is called, but within the scope of the useLayoutEffect, `docUrl` is still an empty string, so when `renderSwaggerUI()` is called, nothing is rendered because docUrl is still considered `""` even though it has been set in the state by `setMetadataAndDocUrl()`
- Another problem is with infinite loading when trying to switch versions. With the way that `usePrevious()` captures information, `prevVersion` and `version` will always be different as they ping pong back and forth:
```js
if (prevVersion !== version) { // "current" !== "0.0.1" so triggers a re-render
  // re-render
}
// on re-render, now prevVersion is "0.0.1" and version is "current" so trigger another re-render
// loop until we break
```

I'm not sure how to solve the issue as the container previously used `prevProps` to get the information which is not the same as a `useRef` which is what `usePrevious` is providing.

Any help fixing these issues would be appreciated!

### Process
- [ ] Tests added or updated for change
- [ ] Docs updated
- [ ] Accessibility concerns have been considered and addressed

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
