### PR TITLE
Fix bug in CurlForm from treating shallow-merged React state as if it were deep-merged

### DIFF
--- a/src/containers/documentation/swaggerPlugins/CurlForm.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.tsx
@@ -94,6 +94,7 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
   public handleInputChange(parameterName: string, value: string): void {
     this.setState({
       paramValues: {
+        ...this.state.paramValues,
         [parameterName]: value,
       },
     });


### PR DESCRIPTION
### Description
<!-- 
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

fixing a bug in the `CurlForm`. https://lighthouseva.slack.com/archives/CDNA4T352/p1605024572060900

### Process
<!-- 
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation 
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them. 
-->
- [ ] Tests added or updated for change
  - ran `CurlForm.test.tsx`
  - part of the problem is that the `CurlForm` unit tests are disabled temporarily because they are very cost-intensive right now. need to refactor to be much more efficient, will create/flag this ticket after this PR gets merged.
- [n/a] Docs updated
- [n/a] Accessibility concerns have been considered and addressed
  - bug would definitely qualify as an accessibility issue, fixed

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
