### PR TITLE
Use Router instead of BrowserRouter so that React Router uses our custom history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
-import { Route, BrowserRouter } from 'react-router-dom';
+import { Route, Router } from 'react-router-dom';
 import { Footer, Header, PageContent } from './components';
 import { FlagsProvider, getFlags } from './flags';
+import { history } from './store';
 
 import 'highlight.js/styles/atom-one-dark-reasonable.css';
 import './styles/base.scss';
@@ -15,7 +16,7 @@ import './styles/base.scss';
  */
 const App = (): JSX.Element => (
   <FlagsProvider flags={getFlags()}>
-    <BrowserRouter>
+    <Router history={history}>
       <div className="vads-u-display--flex">
         <div
           className={classNames(
@@ -30,7 +31,7 @@ const App = (): JSX.Element => (
           <Footer />
         </div>
       </div>
-    </BrowserRouter>
+    </Router>
   </FlagsProvider>
 );
 


### PR DESCRIPTION
### Description
<!-- 
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

when we uninstalled `connected-react-router`, we accidentally introduced a bug in the Apply flow. for some reason, using separate history objects [within `BrowserRouter`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/BrowserRouter.js#L11) and in our app means that the site routing doesn't respond to programmatic changes from our history object. to fix this issue, we need to use `Router` and pass our history object as a prop: https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/BrowserRouter.js#L30

going to deploy as soon as this gets merged.

### Process
<!-- 
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation 
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them. 
-->
- [n/a] Tests added or updated for change
  - we need integration tests for this, may try to add some but also need to get this change deployed
- [n/a] Docs updated
- [n/a] Accessibility concerns have been considered and addressed

#### Manual Testing

to verify the changes, go through the Apply flow and verify that you land on the success page with your credentials. the old behavior is that it will never render the success page with the credentials.

### Requested feedback
<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
