### PR TITLE
Add initial tests for AuthorizationCard

### DIFF
--- a/src/components/authorizationCard/AuthorizationCard.test.tsx
+++ b/src/components/authorizationCard/AuthorizationCard.test.tsx
@@ -1,34 +1,40 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import 'jest';
 import * as React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { AuthorizationCard } from '..';
-
-const renderAuthorizationCard = (categoryKey?: string): void => {
-  render(
-    <BrowserRouter>
-      { categoryKey && <AuthorizationCard categoryKey={categoryKey} />}
-      { !categoryKey && <AuthorizationCard />}
-    </BrowserRouter>
-  );
-};
 
 describe('Authorization Card', () => {
   it('should render default link', () => {
-    renderAuthorizationCard();
-    const cardLink = screen.getByRole('link');
-    expect(cardLink).toBeDefined();
-    expect((cardLink as HTMLLinkElement).href).toBe(
-      'http://localhost:4444/explore/authorization'
+    render(
+      <MemoryRouter>
+        <AuthorizationCard />
+      </MemoryRouter>,
     );
+    const cardLink = screen.getByRole('link');
+    expect(cardLink).toHaveAttribute('href', '/explore/authorization');
   });
 
   it('should render link based on passed categoryKey', () => {
-    renderAuthorizationCard('testCategory');
-    const cardLink = screen.getByRole('link');
-    expect(cardLink).toBeDefined();
-    expect((cardLink as HTMLLinkElement).href).toBe(
-      'http://localhost:4444/explore/testCategory/docs/authorization'
+    render(
+      <MemoryRouter>
+        <AuthorizationCard categoryKey="test" />
+      </MemoryRouter>,
     );
+    const cardLink = screen.getByRole('link');
+    expect(cardLink).toHaveAttribute('href', '/explore/test/docs/authorization');
+  });
+
+  it('should render correct text content', () => {
+    render(
+      <MemoryRouter>
+        <AuthorizationCard />
+      </MemoryRouter>,
+    );
+    const elementContainingContent = screen.getByText(
+      'Use the OpenID Connect standard to allow Veterans to authorize third-party application to access data on their behalf.',
+    );
+    expect(elementContainingContent).toBeDefined();
   });
 });

--- a/src/components/authorizationCard/AuthorizationCard.test.tsx
+++ b/src/components/authorizationCard/AuthorizationCard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import 'jest';
+import * as React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { AuthorizationCard } from '..';
+
+const renderAuthorizationCard = (categoryKey?: string): void => {
+  render(
+    <BrowserRouter>
+      { categoryKey && <AuthorizationCard categoryKey={categoryKey} />}
+      { !categoryKey && <AuthorizationCard />}
+    </BrowserRouter>
+  );
+};
+
+describe('Authorization Card', () => {
+  it('should render default link', () => {
+    renderAuthorizationCard();
+    const cardLink = screen.getByRole('link');
+    expect(cardLink).toBeDefined();
+    expect((cardLink as HTMLLinkElement).href).toBe(
+      'http://localhost:4444/explore/authorization'
+    );
+  });
+
+  it('should render link based on passed categoryKey', () => {
+    renderAuthorizationCard('testCategory');
+    const cardLink = screen.getByRole('link');
+    expect(cardLink).toBeDefined();
+    expect((cardLink as HTMLLinkElement).href).toBe(
+      'http://localhost:4444/explore/testCategory/docs/authorization'
+    );
+  });
+});


### PR DESCRIPTION
### Description
This adds a test for the AuthorizationCard component.

Jira Ticket: https://vajira.max.gov/browse/API-3756

There were discussions about enabling the imported extend-expect to be available in all of our tests without needing imports on the individual files. That being a decision requiring input and buy in from other teams, I created another Jira ticket for us to cover it (https://vajira.max.gov/browse/API-3947). Note that I do have it working in my local, but I wanted to separate the two PRs.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [x] Tests added or updated for change
- [N/A Docs updated
  - [N/A] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [N/A] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [N/A] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [N/A] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

Are the tests adequate? Anything I should change?
