### PR TITLE
API-3736/support contact us form fetch migration

### DIFF
--- a/src/containers/support/SupportContactUsForm.test.tsx
+++ b/src/containers/support/SupportContactUsForm.test.tsx
@@ -1,4 +1,3 @@
-// import * as Sentry from '@sentry/browser';
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { mount } from 'enzyme';
@@ -10,6 +9,11 @@ import * as React from 'react';
 
 import { CONTACT_US_URL } from '../../types/constants';
 import SupportContactUsForm from './SupportContactUsForm';
+
+jest.mock('uuid', () => ({
+  __esModule: true,
+  v4: jest.fn(() => '123'),
+}));
 
 const server = setupServer(
   rest.post(
@@ -77,57 +81,6 @@ describe('SupportContactUsForm', () => {
       }),
     );
   });
-
-  /*
-   * it('logs error events in Sentry when fetch returns validation errors with status 400', async () => {
-   * const captureException = jest.spyOn(Sentry, 'captureException');
-   * const fromString = jest.spyOn(Sentry.Severity, 'fromString');
-   * const scope = jest.spyOn(Sentry, 'withScope');
-   *
-   * server.use(
-   *  rest.post(
-   *    CONTACT_US_URL,
-   *    (
-   *      req: MockedRequest,
-   *      res: ResponseComposition,
-   *      context: typeof restContext,
-   *    ): MockedResponse => res(context.status(400), context.json({ errors: ['unknown error'] })),
-   *  ),
-   * );
-   *
-   * const onSuccessMock = jest.fn();
-   *
-   * const { getByLabelText, getByText } = render(
-   *  <SupportContactUsForm onSuccess={onSuccessMock} />,
-   * );
-   *
-   * const firstNameInput = getByLabelText('First name(*Required)');
-   * fireEvent.change(firstNameInput, { target: { value: 'john' } });
-   * const lastNameInput = getByLabelText('Last name(*Required)');
-   * fireEvent.change(lastNameInput, { target: { value: 'doe' } });
-   * const description = getByLabelText(
-   *  'Please describe your question or issue in as much detail as you can provide. Steps to reproduce or any specific error messages are helpful if applicable.(*Required)',
-   * );
-   * fireEvent.change(description, { target: { value: 'this is a test' } });
-   * const emailInput = getByLabelText('Email(*Required)');
-   * fireEvent.change(emailInput, { target: { value: 'hello@test.com' } });
-   * const submitBtn = getByText('Submit');
-   * await waitFor(() => expect(submitBtn).not.toHaveAttribute('disabled', ''));
-   * fireEvent.click(submitBtn);
-   *
-   * await waitFor(() => expect(Sentry.withScope).toHaveBeenCalled());
-   *
-   * expect(Sentry.Severity.fromString).toHaveBeenCalledWith('warning');
-   *
-   * expect(Sentry.captureException).toHaveBeenCalledWith(
-   *  Error('Contact Us Form validation errors: unknown error'),
-   * );
-   *
-   * captureException.mockRestore();
-   * fromString.mockRestore();
-   * scope.mockRestore();
-   * });
-   */
 
   it('should not be disabled when required fields are filled', async () => {
     const onSuccessMock = jest.fn();

--- a/src/containers/support/SupportContactUsForm.test.tsx
+++ b/src/containers/support/SupportContactUsForm.test.tsx
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser';
+// import * as Sentry from '@sentry/browser';
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { mount } from 'enzyme';
@@ -69,7 +69,7 @@ describe('SupportContactUsForm', () => {
           '{"apis":[],"description":"this is a test","email":"test@email.com","firstName":"john","lastName":"doe","organization":""}',
         bodyUsed: true,
         credentials: 'omit',
-        headers: { map: { accept: 'application/json', 'content-type': 'application/json' } },
+        headers: { map: { accept: 'application/json', 'content-type': 'application/json', 'x-request-id': '123' } },
         method: 'POST',
         mode: null,
         referrer: null,
@@ -78,54 +78,56 @@ describe('SupportContactUsForm', () => {
     );
   });
 
-  it('logs error events in Sentry when fetch returns validation errors with status 400', async () => {
-    const captureException = jest.spyOn(Sentry, 'captureException');
-    const fromString = jest.spyOn(Sentry.Severity, 'fromString');
-    const scope = jest.spyOn(Sentry, 'withScope');
-
-    server.use(
-      rest.post(
-        CONTACT_US_URL,
-        (
-          req: MockedRequest,
-          res: ResponseComposition,
-          context: typeof restContext,
-        ): MockedResponse => res(context.status(400), context.json({ errors: ['unknown error'] })),
-      ),
-    );
-
-    const onSuccessMock = jest.fn();
-
-    const { getByLabelText, getByText } = render(
-      <SupportContactUsForm onSuccess={onSuccessMock} />,
-    );
-
-    const firstNameInput = getByLabelText('First name(*Required)');
-    fireEvent.change(firstNameInput, { target: { value: 'john' } });
-    const lastNameInput = getByLabelText('Last name(*Required)');
-    fireEvent.change(lastNameInput, { target: { value: 'doe' } });
-    const description = getByLabelText(
-      'Please describe your question or issue in as much detail as you can provide. Steps to reproduce or any specific error messages are helpful if applicable.(*Required)',
-    );
-    fireEvent.change(description, { target: { value: 'this is a test' } });
-    const emailInput = getByLabelText('Email(*Required)');
-    fireEvent.change(emailInput, { target: { value: 'hello@test.com' } });
-    const submitBtn = getByText('Submit');
-    await waitFor(() => expect(submitBtn).not.toHaveAttribute('disabled', ''));
-    fireEvent.click(submitBtn);
-
-    await waitFor(() => expect(Sentry.withScope).toHaveBeenCalled());
-
-    expect(Sentry.Severity.fromString).toHaveBeenCalledWith('warning');
-
-    expect(Sentry.captureException).toHaveBeenCalledWith(
-      Error('Contact Us Form validation errors: unknown error'),
-    );
-
-    captureException.mockRestore();
-    fromString.mockRestore();
-    scope.mockRestore();
-  });
+  /*
+   * it('logs error events in Sentry when fetch returns validation errors with status 400', async () => {
+   * const captureException = jest.spyOn(Sentry, 'captureException');
+   * const fromString = jest.spyOn(Sentry.Severity, 'fromString');
+   * const scope = jest.spyOn(Sentry, 'withScope');
+   *
+   * server.use(
+   *  rest.post(
+   *    CONTACT_US_URL,
+   *    (
+   *      req: MockedRequest,
+   *      res: ResponseComposition,
+   *      context: typeof restContext,
+   *    ): MockedResponse => res(context.status(400), context.json({ errors: ['unknown error'] })),
+   *  ),
+   * );
+   *
+   * const onSuccessMock = jest.fn();
+   *
+   * const { getByLabelText, getByText } = render(
+   *  <SupportContactUsForm onSuccess={onSuccessMock} />,
+   * );
+   *
+   * const firstNameInput = getByLabelText('First name(*Required)');
+   * fireEvent.change(firstNameInput, { target: { value: 'john' } });
+   * const lastNameInput = getByLabelText('Last name(*Required)');
+   * fireEvent.change(lastNameInput, { target: { value: 'doe' } });
+   * const description = getByLabelText(
+   *  'Please describe your question or issue in as much detail as you can provide. Steps to reproduce or any specific error messages are helpful if applicable.(*Required)',
+   * );
+   * fireEvent.change(description, { target: { value: 'this is a test' } });
+   * const emailInput = getByLabelText('Email(*Required)');
+   * fireEvent.change(emailInput, { target: { value: 'hello@test.com' } });
+   * const submitBtn = getByText('Submit');
+   * await waitFor(() => expect(submitBtn).not.toHaveAttribute('disabled', ''));
+   * fireEvent.click(submitBtn);
+   *
+   * await waitFor(() => expect(Sentry.withScope).toHaveBeenCalled());
+   *
+   * expect(Sentry.Severity.fromString).toHaveBeenCalledWith('warning');
+   *
+   * expect(Sentry.captureException).toHaveBeenCalledWith(
+   *  Error('Contact Us Form validation errors: unknown error'),
+   * );
+   *
+   * captureException.mockRestore();
+   * fromString.mockRestore();
+   * scope.mockRestore();
+   * });
+   */
 
   it('should not be disabled when required fields are filled', async () => {
     const onSuccessMock = jest.fn();

--- a/src/containers/support/SupportContactUsForm.tsx
+++ b/src/containers/support/SupportContactUsForm.tsx
@@ -124,7 +124,7 @@ const SupportContactUsForm = (props: SupportContactUsFormProps): JSX.Element => 
     organization: formState.organization.value,
   });
 
-  const formSubmission = async (): Promise<void> =>
+  const formSubmission = (): Promise<void> =>
     makeRequest(CONTACT_US_URL, {
       body: JSON.stringify(processedData()),
       headers: {

--- a/src/containers/support/SupportContactUsForm.tsx
+++ b/src/containers/support/SupportContactUsForm.tsx
@@ -1,7 +1,6 @@
 import ErrorableCheckboxGroup from '@department-of-veterans-affairs/formation-react/ErrorableCheckboxGroup';
 import ErrorableTextArea from '@department-of-veterans-affairs/formation-react/ErrorableTextArea';
 import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
-import * as Sentry from '@sentry/browser';
 import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -11,6 +10,7 @@ import { getApiDefinitions } from '../../apiDefs/query';
 import { Form } from '../../components';
 import { ErrorableInput } from '../../types';
 import { CONTACT_US_URL } from '../../types/constants';
+import { makeRequest, ResponseType } from '../../utils/makeRequest';
 import { validateEmail, validatePresence } from '../../utils/validators';
 
 import './SupportContactUsForm.scss';
@@ -124,37 +124,20 @@ const SupportContactUsForm = (props: SupportContactUsFormProps): JSX.Element => 
     organization: formState.organization.value,
   });
 
-  const formSubmission = (): Promise<void> => {
-    const request = new Request(CONTACT_US_URL, {
+  const formSubmission = async (): Promise<void> =>
+    makeRequest(CONTACT_US_URL, {
       body: JSON.stringify(processedData()),
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
       },
       method: 'POST',
-    });
-
-    return fetch(request)
-      .then(response => {
-        // The developer-portal-backend sends a 400 status, along with an array of validation error strings, when validation errors are present on the form.
-        if (!response.ok && response.status !== 400) {
-          throw Error(response.statusText);
-        }
-        return response;
-      })
-      .then(response => response.json())
-      .then((json: { errors?: string[] }) => {
-        if (json.errors) {
-          throw Error(`Contact Us Form validation errors: ${json.errors.join(', ')}`);
-        }
-      })
+    }, { responseType: ResponseType.TEXT }).then(() => {
+      // do nothing and return void
+    })
       .catch(error => {
-        Sentry.withScope(scope => {
-          scope.setLevel(Sentry.Severity.fromString('warning'));
-          Sentry.captureException(error);
-        });
+        throw error;
       });
-  };
 
   const toggleApis = (input: ErrorableInput, checked: boolean): void => {
     const name = input.value;


### PR DESCRIPTION
### [API-3736](https://vajira.max.gov/browse/API-3736)
Fetch logic migrated to use the wrapper. This component no longer needs to handle integration with Sentry.

### Process
- [X] Tests added or updated for change
- [N/A] Docs updated
  - [N/A] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [N/A] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [N/A] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [N/A] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

