### PR TITLE
API-3529 - Test ApplyForm and related components

### DIFF
--- a/src/containers/apply/ApplyForm.test.tsx
+++ b/src/containers/apply/ApplyForm.test.tsx
@@ -1,0 +1,126 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { createStore, combineReducers, compose, applyMiddleware, AnyAction } from 'redux';
+import thunk, { ThunkMiddleware, ThunkAction } from 'redux-thunk';
+import * as applyActions from '../../actions/apply';
+import { application, initialApplicationState } from '../../reducers';
+import { apiVersioning } from '../../reducers/api-versioning';
+import { RootState } from '../../types';
+
+import { ApplyForm } from './ApplyForm';
+
+let spyDispatch: jest.SpyInstance<unknown, [ThunkAction<unknown, RootState, undefined, AnyAction>]>;
+
+describe('ApplyForm', () => {
+  beforeEach(() => {
+    const store = createStore(
+      combineReducers<RootState>({
+        apiVersioning,
+        application,
+      }),
+      {
+        application: initialApplicationState,
+      },
+      compose(applyMiddleware(thunk as ThunkMiddleware<RootState>)),
+    );
+
+    spyDispatch = jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ApplyForm />
+        </MemoryRouter>
+      </Provider>,
+    );
+  });
+
+  it('should successfully render', () => {
+    expect(
+      screen.getByRole('region', { name: 'Apply for VA Lighthouse Developer Access' }),
+    ).toBeInTheDocument();
+  });
+
+  describe('description textarea', () => {
+    it('should update input on typing', async () => {
+      const descriptionTextarea: HTMLInputElement = screen.getByRole('textbox', {
+        name: 'Briefly describe how your organization will use VA APIs:',
+      }) as HTMLInputElement;
+
+      await userEvent.type(descriptionTextarea, 'One Ring to rule them all');
+
+      expect(descriptionTextarea.value).toBe('One Ring to rule them all');
+    });
+  });
+
+  describe('terms of service', () => {
+    it('should toggle when clicked', () => {
+      const tosCheckbox: HTMLInputElement = screen.getByRole('checkbox', {
+        name: /Terms of Service/,
+      }) as HTMLInputElement;
+
+      expect(tosCheckbox).toBeInTheDocument();
+      expect(tosCheckbox).not.toBeChecked();
+
+      userEvent.click(tosCheckbox);
+
+      expect(tosCheckbox).toBeChecked();
+    });
+
+    it('should contain a link to the terms of service page', () => {
+      const tosLink = screen.getByRole('link', { name: 'Terms of Service' });
+
+      expect(tosLink).toBeInTheDocument();
+      expect(tosLink.getAttribute('href')).toBe('/terms-of-service');
+    });
+  });
+
+  describe('submit button', () => {
+    it('is disabled when not all required fields are filled in', async () => {
+      const submitButton: HTMLButtonElement = screen.getByRole('button', {
+        name: 'Submit',
+      }) as HTMLButtonElement;
+
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).toBeDisabled();
+
+      await userEvent.type(screen.getByRole('textbox', { name: /First name/ }), 'Peregrin');
+      await userEvent.type(screen.getByRole('textbox', { name: /Last name/ }), 'Took');
+      await userEvent.type(screen.getByRole('textbox', { name: /Email/ }), 'pippin@theshire.net');
+      await userEvent.type(screen.getByRole('textbox', { name: /^Organization/ }), 'Fellowship');
+      userEvent.click(screen.getByRole('checkbox', { name: /VA Benefits API/ }));
+
+      expect(submitButton).toBeDisabled();
+
+      userEvent.click(screen.getByRole('checkbox', { name: /Terms of Service/ }));
+
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    it('submits the form when enabled and clicked', async () => {
+      await userEvent.type(screen.getByRole('textbox', { name: /First name/ }), 'Meriadoc');
+      await userEvent.type(screen.getByRole('textbox', { name: /Last name/ }), 'Brandybuck');
+      await userEvent.type(screen.getByRole('textbox', { name: /Email/ }), 'merry@theshire.net');
+      await userEvent.type(screen.getByRole('textbox', { name: /^Organization/ }), 'Fellowship');
+      userEvent.click(screen.getByRole('checkbox', { name: /VA Benefits API/ }));
+      userEvent.click(screen.getByRole('checkbox', { name: /Terms of Service/ }));
+
+      const mockActionsReturn = jest.fn();
+      const spyActions = jest.spyOn(applyActions, 'submitForm');
+      spyActions.mockReturnValueOnce(mockActionsReturn);
+
+      const submitButton: HTMLButtonElement = screen.getByRole('button', {
+        name: 'Submit',
+      }) as HTMLButtonElement;
+
+      userEvent.click(submitButton);
+
+      expect(spyActions).toHaveBeenCalledTimes(1);
+      expect(spyDispatch).toHaveBeenCalledWith(mockActionsReturn);
+    });
+  });
+});

--- a/src/containers/apply/ApplyHeader.test.tsx
+++ b/src/containers/apply/ApplyHeader.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import ApplyHeader from './ApplyHeader';
+
+describe('ApplyHeader', () => {
+  beforeEach(() => {
+    render(
+      <MemoryRouter>
+        <ApplyHeader />
+      </MemoryRouter>,
+    );
+  });
+
+  it('renders succesfully', () => {
+    expect(
+      screen.getByRole('heading', { name: 'Apply for VA Lighthouse Developer Access' }),
+    ).toBeInTheDocument();
+  });
+
+  it('contains a link to request production access', () => {
+    const requestLink = screen.getByRole('link', { name: 'request production access' });
+
+    expect(requestLink).toBeInTheDocument();
+    expect(requestLink.getAttribute('href')).toBe('/go-live');
+  });
+});

--- a/src/containers/apply/DeveloperInfo.test.tsx
+++ b/src/containers/apply/DeveloperInfo.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router';
 import store from '../../store';
 import { DeveloperInfo } from './DeveloperInfo';
 
@@ -11,9 +10,7 @@ describe('DeveloperInfo', () => {
   beforeEach(() => {
     render(
       <Provider store={store}>
-        <MemoryRouter>
-          <DeveloperInfo />
-        </MemoryRouter>
+        <DeveloperInfo />
       </Provider>,
     );
   });

--- a/src/containers/apply/DeveloperInfo.test.tsx
+++ b/src/containers/apply/DeveloperInfo.test.tsx
@@ -1,0 +1,90 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import store from '../../store';
+import { DeveloperInfo } from './DeveloperInfo';
+
+describe('DeveloperInfo', () => {
+  beforeEach(() => {
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <DeveloperInfo />
+        </MemoryRouter>
+      </Provider>,
+    );
+  });
+
+  it('renders successfully', () => {
+    expect(screen.getByRole('textbox', { name: 'First name (*Required)' })).toBeInTheDocument();
+  });
+
+  describe('first name', () => {
+    it('updates the textbox on user input', async () => {
+      const input: HTMLInputElement = screen.getByRole('textbox', {
+        name: 'First name (*Required)',
+      }) as HTMLInputElement;
+
+      expect(input.value).toBe('');
+
+      await userEvent.type(input, 'Aragorn');
+
+      expect(input.value).toBe('Aragorn');
+    });
+  });
+
+  describe('last name', () => {
+    it('updates the textbox on user input', async () => {
+      const input: HTMLInputElement = screen.getByRole('textbox', {
+        name: 'Last name (*Required)',
+      }) as HTMLInputElement;
+
+      expect(input.value).toBe('');
+
+      await userEvent.type(input, 'Son of Arathorn');
+
+      expect(input.value).toBe('Son of Arathorn');
+    });
+  });
+  describe('email', () => {
+    it('updates the email textbox on user input', async () => {
+      const input: HTMLInputElement = screen.getByRole('textbox', {
+        name: 'Email (*Required)',
+      }) as HTMLInputElement;
+
+      expect(input.value).toBe('');
+
+      await userEvent.type(input, 'strider@gondor.org');
+
+      expect(input.value).toBe('strider@gondor.org');
+    });
+
+    it('displays an error message when given an invalid email address', async () => {
+      await userEvent.type(
+        screen.getByRole('textbox', { name: 'Email (*Required)' }),
+        'strider@gondor',
+      );
+      userEvent.tab();
+
+      const error = screen.getByRole('alert');
+      expect(error).toHaveTextContent('Must be a valid email address.');
+    });
+  });
+
+  describe('organization', () => {
+    it('updates the organization textbox on user input', async () => {
+      const input: HTMLInputElement = screen.getByRole('textbox', {
+        name: 'Organization (*Required)',
+      }) as HTMLInputElement;
+
+      expect(input.value).toBe('');
+
+      await userEvent.type(input, 'Kingdom of Gondor');
+
+      expect(input.value).toBe('Kingdom of Gondor');
+    });
+  });
+});

--- a/src/containers/apply/OAuthAppInfo.test.tsx
+++ b/src/containers/apply/OAuthAppInfo.test.tsx
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import store from '../../store';
+import { OAuthAppInfo } from './OAuthAppInfo';
+
+describe('OAuthAppInfo', () => {
+  beforeEach(() => {
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <OAuthAppInfo />
+        </MemoryRouter>
+      </Provider>,
+    );
+  });
+
+  it('renders successfully', () => {
+    expect(
+      screen.getByRole('group', {
+        name: 'Can your application securely hide a client secret? (*Required)',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('contains a link to documentation on "authorization code flow"', () => {
+    const authCodeFlowLink = screen.getByRole('link', { name: 'authorization code flow' });
+
+    expect(authCodeFlowLink).toBeInTheDocument();
+    expect(authCodeFlowLink.getAttribute('href')).toBe(
+      'https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/',
+    );
+  });
+
+  it('contains a link to documentation on "PKCE flow"', () => {
+    const authCodeFlowLink = screen.getByRole('link', { name: 'PKCE flow' });
+
+    expect(authCodeFlowLink).toBeInTheDocument();
+    expect(authCodeFlowLink.getAttribute('href')).toBe(
+      'https://www.oauth.com/oauth2-servers/pkce/',
+    );
+  });
+
+  it('updates radio button choices on selection', () => {
+    const [yesRadio, noRadio]: HTMLInputElement[] = screen.getAllByRole(
+      'radio',
+    ) as HTMLInputElement[];
+
+    expect(yesRadio.checked).toBeFalsy();
+    expect(noRadio.checked).toBeFalsy();
+
+    userEvent.click(yesRadio);
+
+    expect(yesRadio.checked).toBeTruthy();
+    expect(noRadio.checked).toBeFalsy();
+
+    userEvent.click(noRadio);
+
+    expect(yesRadio.checked).toBeFalsy();
+    expect(noRadio.checked).toBeTruthy();
+  });
+
+  it('updates the redirect URI textbox on user input', async () => {
+    const input: HTMLInputElement = screen.getByRole('textbox', {
+      name: 'OAuth Redirect URI (*Required)',
+    }) as HTMLInputElement;
+
+    expect(input.value).toBe('');
+
+    await userEvent.type(input, 'http://www.dunedain.com');
+
+    expect(input.value).toBe('http://www.dunedain.com');
+  });
+});

--- a/src/containers/apply/SelectedApis.test.tsx
+++ b/src/containers/apply/SelectedApis.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import store from '../../store';
+import SelectedApis from './SelectedApis';
+
+describe('SelectedApis', () => {
+  beforeEach(() => {
+    render(
+      <Provider store={store}>
+        <SelectedApis />
+      </Provider>,
+    );
+  });
+
+  it('renders successfully', () => {
+    expect(
+      screen.getByRole('group', { name: "Please select all of the APIs you'd like access to:" }),
+    ).toBeInTheDocument();
+  });
+
+  describe('Standard APIs', () => {
+    const standardApis = [
+      'VA Benefits API',
+      'VA Facilities API',
+      'VA Forms API',
+      'VA Veteran Confirmation API',
+    ];
+
+    it.each(standardApis)('contains the %s checkbox', name => {
+      expect(screen.getByRole('checkbox', { name })).toBeInTheDocument();
+    });
+
+    it.each(standardApis)('toggles the %s checkbox on click', name => {
+      const checkbox: HTMLInputElement = screen.getByRole('checkbox', { name }) as HTMLInputElement;
+      expect(checkbox.checked).toBeFalsy();
+
+      userEvent.click(checkbox);
+
+      expect(checkbox.checked).toBeTruthy();
+    });
+  });
+
+  describe('OAuth APIs', () => {
+    const oauthApis = [
+      'VA Claims API',
+      'VA Health API',
+      'Community Care Eligibility API',
+      'VA Veteran Verification API',
+    ];
+
+    it.each(oauthApis)('contains the %s checkbox', name => {
+      expect(screen.getByRole('checkbox', { name })).toBeInTheDocument();
+    });
+
+    it.each(oauthApis)('toggles the %s checkbox on click', name => {
+      const checkbox: HTMLInputElement = screen.getByRole('checkbox', { name }) as HTMLInputElement;
+      expect(checkbox.checked).toBeFalsy();
+
+      userEvent.click(checkbox);
+
+      expect(checkbox.checked).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
### Description

This PR is for [API-3529](https://vajira.max.gov/browse/API-3529); it adds testing for the ApplyForm and it's associated components (aside from ApplySuccess, which will be covered in a separate ticket).

![image](https://user-images.githubusercontent.com/22045453/102568966-3869ae00-40aa-11eb-899d-8883ae464db6.png)


- [X] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

Any feedback welcome