### PR TITLE
Update Skip Nav links to respect query params

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import { Banner, NavBar } from '../../components';
 import { Flag } from '../../flags';
@@ -23,6 +23,7 @@ const Header = (): JSX.Element => {
    */
   const [mobileNavVisible, setMobileNavVisible] = React.useState(false);
 
+  const location = useLocation();
   const toggleMenuVisible = (): void => {
     setMobileNavVisible((state: boolean) => !state);
   };
@@ -40,7 +41,7 @@ const Header = (): JSX.Element => {
         className={classNames('va-api-header', 'vads-u-background-color--primary-darkest')}
       >
         <HashLink
-          to="#main"
+          to={{ ...location, hash: '#main' }}
           className={classNames('va-api-skipnav', 'vads-u-padding-x--2', 'vads-u-padding-y--1')}
         >
           Skip to main content

--- a/src/components/sideNav/SideNav.tsx
+++ b/src/components/sideNav/SideNav.tsx
@@ -47,7 +47,7 @@ const SideNav = (props: SideNavProps): JSX.Element => {
           'vads-u-display--block',
           'vads-u-color--white',
         )}
-        to="#page-header"
+        to={{ ...location, hash: '#page-header' }}
       >
         Skip Page Navigation
       </HashLink>


### PR DESCRIPTION
### Description
The primary and secondary skip nav items don't respect query strings as is. This resolves that issue. Was found during the new auth docs development but is an issue on the API pages currently.

### Process
- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback