### PR TITLE
Cut over main release and production deploy to CodeBuild

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,9 +74,8 @@ def reviewBucketPath() {
   return "${review_s3_bucket_name}/${shortRef}"
 }
 
-
 node('vetsgov-general-purpose') {
-  properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]]);
+  properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]])
   def dockerImage, args, imageTag
 
   // Checkout source, create output directories, build container
@@ -106,7 +105,7 @@ node('vetsgov-general-purpose') {
       shortRef = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
 
       if (prNum) {
-        envNames.each{ envName ->
+        envNames.each { envName ->
           // Set public url so review deploys handle not being at the site root
           // Set sentry DSN to send review deploy errors to the review sentry project
           writeFile(
@@ -119,13 +118,12 @@ node('vetsgov-general-purpose') {
         }
       }
 
-      sh "mkdir -p build"
+      sh 'mkdir -p build'
 
-      imageTag = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-
+      imageTag = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", '-')
 
       docker.withRegistry('https://index.docker.io/v1/', 'vasdvdocker') {
-      	dockerImage = docker.build("developer-portal:${imageTag}")
+        dockerImage = docker.build("developer-portal:${imageTag}")
         args = "-v ${pwd()}:/application -v /application/node_modules"
       }
     } catch (error) {
@@ -135,15 +133,15 @@ node('vetsgov-general-purpose') {
   }
 
   stage('Image Prohibition') {
-		if (!onDeployableBranch()) {
-			sh "./prohibit_image_files.sh origin/master HEAD"
-		} 
+    if (!onDeployableBranch()) {
+      sh './prohibit_image_files.sh origin/master HEAD'
+    }
   }
 
   stage('Security') {
     try {
       dockerImage.inside(args) {
-        sh "cd /application && npm audit --audit-level moderate"
+        sh 'cd /application && npm audit --audit-level moderate'
       }
     } catch (error) {
       if (!onDeployableBranch()) {
@@ -195,7 +193,7 @@ node('vetsgov-general-purpose') {
     }
   }
 
-  stage('Accessibility Test'){
+  stage('Accessibility Test') {
     try {
       dockerImage.inside(args) {
         sh 'cd /application && npm run-script test:accessibility:ci'
@@ -217,7 +215,7 @@ node('vetsgov-general-purpose') {
       }
     } catch (error) {
       dir('test/image_snapshots/__diff_output__') {
-        withEnv(["ref=${ref}",'bucket=developer-portal-screenshots']) {
+        withEnv(["ref=${ref}", 'bucket=developer-portal-screenshots']) {
           // Upload diffs to S3
           withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload', usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
             sh 'aws --region us-gov-west-1 s3 sync --no-progress . "s3://${bucket}/${ref}/"'
@@ -244,7 +242,7 @@ node('vetsgov-general-purpose') {
 
     try {
       def builds = [:]
-      envNames.each{ envName ->
+      envNames.each { envName ->
         builds[envName] = {
           dockerImage.inside(args) {
             sh "cd /application && NODE_ENV=production BUILD_ENV=${envName} npm run-script build ${envName}"
@@ -268,16 +266,16 @@ node('vetsgov-general-purpose') {
 
     // This could only happen in the rare case that a PR is opened from master -> another branch,
     // which is unlikely, but potentially disastrous.
-    if (prNum) { return } 
+    if (prNum) { return }
 
     try {
       withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload',
                         usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
-        envNames.each{ envName ->
+        envNames.each { envName ->
           sh "tar -C build/${envName} -cf build/${envName}.tar.bz2 ."
-          sh "aws --region us-gov-west-1 s3 cp --no-progress --acl public-read build/${envName}.tar.bz2 s3://developer-portal-builds-s3-upload/${ref}/${envName}.tar.bz2"
+          sh "aws --region us-gov-west-1 s3 cp --no-progress --acl public-read build/${envName}.tar.bz2 s3://developer-portal-builds-s3-upload/jenkins-${ref}/${envName}.tar.bz2"
         }
-      }
+                        }
     } catch (error) {
       notify()
       throw error

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -10,23 +10,23 @@
 
 ## Overview
 
-This pipeline will utilize a Makefile from the root directory to invoke the testing options. The Makefile gives the developer the opportunity to run the CI process locally in order to get instant feedback on their work. 
+This pipeline will utilize a Makefile from the root directory to invoke the testing options. The Makefile gives the developer the opportunity to run the CI process locally in order to get instant feedback on their work.
 
-## CI 
+## CI
 
-The CI process is triggered on every `PUSH` event and every `PULL REQUEST` event. Depending the variables for each event will dictate which artifacts are produced. 
+The CI process is triggered on every `PUSH` event and every `PULL REQUEST` event. Depending the variables for each event will dictate which artifacts are produced.
 
 ### Makefile
 
 To run tests simply type `make <test>` where <test> is the type of test you would like to run, for example `make lint`. Run `make` to get an output of targets you can run.
 
- The tests are run in a container. This container currently runs as the user __jenkins__ which you most likely do not have on your machine. The tests that are run are also the same test that run in __CI__ , resulting in the tests outputting a report file. This report file most likely will have trouble writing to your local machine as the __jenkins__ user. Therefore, you can export a variable to set the user the container will run as. This user in most all cases will be __root__. To do this you merely have to run `export UNAME=root`. You can also do the same for the group; `export GNAME=root`.
+The tests are run in a container. This container currently runs as the user **jenkins** which you most likely do not have on your machine. The tests that are run are also the same test that run in **CI** , resulting in the tests outputting a report file. This report file most likely will have trouble writing to your local machine as the **jenkins** user. Therefore, you can export a variable to set the user the container will run as. This user in most all cases will be **root**. To do this you merely have to run `export UNAME=root`. You can also do the same for the group; `export GNAME=root`.
 
 ### Feature Branch Push
 
 A feature branch commit will:
 
-1. Run all tests assigned to the `TESTS` variable in the `buildspec-ci.yml` file. 
+1. Run all tests assigned to the `TESTS` variable in the `buildspec-ci.yml` file.
 2. Perform a build for each environment.
 3. On error it will upload the applicable error report to the s3 error bucket listed in the `buildspec-ci.yml` file.
 
@@ -45,24 +45,24 @@ This scenario will run all steps listed in [Feature Branch Push](#feature-branch
 
 ### Master Branch Push
 
-This scenario will run steps listed in [Feature Branch Push](#feature-branch-push) _with following changes:
+This scenario will run steps listed in [Feature Branch Push](#feature-branch-push) \_with following changes:
 
-1. Failed `make security` will fail CI. 
+1. Failed `make security` will fail CI.
 2. Deployment files will be uploaded to the archive bucket as a tar file for deployment.
 
 ## Knobs and Iterations
 
 ### Adding Tests
 
-If you want to add new test script you will also want to incorporate it into the Makefile. You can use the Makefile to iterate on your test and to incorporate it into the CI pipeline in one shot. Here is a breakdown of a process to develop a script that will use `npm run-script test:newtest:ci ` to run locally and in CI.
+If you want to add new test script you will also want to incorporate it into the Makefile. You can use the Makefile to iterate on your test and to incorporate it into the CI pipeline in one shot. Here is a breakdown of a process to develop a script that will use `npm run-script test:newtest:ci` to run locally and in CI.
 
 This is a comment that will show up when `make` or `make help` is run to inform the user what the target does:
 
-`## newtest:		runs a newtest`
+`## newtest: runs a newtest`
 
 This will assign an explicit request to the target
 
-`.PHONY: newtest` 
+`.PHONY: newtest`
 
 This is your target
 
@@ -79,10 +79,10 @@ docker run --rm \
 	--user ${UNAME}:${GNAME} \
 	--volume "/application/node_modules" \
 	--volume "${PWD}:/application" \
-	developer-portal npm run test:newtest:ci 
+	developer-portal npm run test:newtest:ci
 ```
 
-After this is added you can then run `make build` then `make newtest` to run your tests locally. If you need to make changes to your script you can run the same commands in succession. Alternatively, for the iteration process you can add this `newtest: build` and that will run build on every `make newtest`.  
+After this is added you can then run `make build` then `make newtest` to run your tests locally. If you need to make changes to your script you can run the same commands in succession. Alternatively, for the iteration process you can add this `newtest: build` and that will run build on every `make newtest`.
 
 Lastly add your new test to `make test`
 
@@ -92,7 +92,7 @@ Lastly add your new test to `make test`
 test: security unit lint accessibility e2e visual newtest
 ```
 
-Once your test runs on your local machine quite handsomely you can push it to the repo and test if it works in CodeBuild as you expected. For this iteration you can feel free to edit the `buildspec-ci.yml` file to only incorporate your test, this will make your feedback loop much faster. To do this simply edit the `TESTS` variable demonstrated below. As reminder, make sure you change it back prior to merge! 
+Once your test runs on your local machine quite handsomely you can push it to the repo and test if it works in CodeBuild as you expected. For this iteration you can feel free to edit the `buildspec-ci.yml` file to only incorporate your test, this will make your feedback loop much faster. To do this simply edit the `TESTS` variable demonstrated below. As reminder, make sure you change it back prior to merge!
 
 ### Incorporating new test Up CodeBuild
 
@@ -121,23 +121,45 @@ Also set up the error handling for you're test in the post_build section:
           ;;
 ```
 
-
-
 ### Adding PR Comments and Slack posts
 
-Two scripts are available; one for commenting on PRs and one for posting to Slack. 
+Two scripts are available; one for commenting on PRs and one for posting to Slack.
 
-The PR comment script uses a block at the bottom to evaluate if a PR number exsists and then comments on the PR utilizing whatever the `comment` variable is set too. To add a comment merely change the assignment of the comment variable to what you need. 
+The PR comment script uses a block at the bottom to evaluate if a PR number exsists and then comments on the PR utilizing whatever the `comment` variable is set too. To add a comment merely change the assignment of the comment variable to what you need.
 
-For Slack, the web hook is currently set to the DSVA workspace and posts to the Lighthouse deploys channel. There is a To Do item to move that over to lighthouse workspace and add more web hooks to post to appropriate channels based upon the information needed to be communicated. 
+For Slack, the web hook is currently set to the DSVA workspace and posts to the Lighthouse deploys channel. There is a To Do item to move that over to lighthouse workspace and add more web hooks to post to appropriate channels based upon the information needed to be communicated.
 
 ## Releases
 
-Release
+Releases are managed by the [`developer-portal-release`](https://us-gov-west-1.console.amazonaws-us-gov.com/codesuite/codebuild/008577686731/projects/developer-portal-release/history?region=us-gov-west-1) job in CodeBuild. The release job runs on each commit to `master`. It creates a new release in Github using the artifacts from the commit and the [gh](https://cli.github.com/manual/) CLI tool.
+
+The release job also kicks off the deploy job in the dev and staging environments. To deploy changes to production, an engineer must manually run the deploy job for production; see [Deployments](#deployments) for details. Engineers should always plan to deploy changes when they have merged them to `master` to avoid batching together several commits in one deploy and should always communicate exceptions clearly in the Lighthouse Slack.
 
 ## Deployments
 
-Deploying
+Deployments are managed by the [`developer-portal-deploy`](https://us-gov-west-1.console.amazonaws-us-gov.com/codesuite/codebuild/008577686731/projects/developer-portal-deploy/history?region=us-gov-west-1) job in CodeBuild. The deploy job runs automatically for dev and staging for each release; it must be run manually for deploys to production.
+
+To deploy to production, engineers should create a [Maintenance Request (MR)](https://github.com/department-of-veterans-affairs/lighthouse-devops-support/issues/new/choose) in the [`lighthouse-devops-support`](https://github.com/department-of-veterans-affairs/lighthouse-devops-support) repo. You can use the following values for the MR:
+
+```
+Environment: dsva-production
+Product: developer-portal
+Deployment steps:
+- Run the developer-portal-deploy job with ENVIRONMENTS=production and MR=<this issue number>.
+
+Rollback steps:
+- Run the developer-portal-deploy job with ENVIRONMENTS=production, MR=<this issue number>, and RELEASE=<previous release> or COMMIT_HASH=<previous commit>. (Pick one of RELEASE or COMMIT_HASH and fill out the real values you'll use.)
+```
+
+At the scheduled time of the deploy from the MR, follow these steps to deploy.
+
+1. Go to the `developer-portal-deploy` job in CodeBuild.
+2. Click the "Start build with overrides" button.
+3. _Do not modify anything outside of the "Environment variables override" section._
+4. Under the "Environment variables override" section, add the `ENVIRONMENTS` variable and set it to `production`. You may optionally include `dev` or `staging` in the value, separated by spaces, but unless you are rolling back changes, those environments should already have been deployed automatically.
+5. Under the "Environment variables override" section, add the `MR` variable with either the number of the MR issue in the `lighthouse-devops-support` repo or a link to the issue. _The deploy job will fail without this variable set._
+6. _(optional)_ You can optionally set the `RELEASE` variable to the release tag or the `COMMIT_HASH` to the git ref you want to deploy. If neither variable is set, it deploys the latest release, which is usually the correct choice. If both are set, the `RELEASE` variable takes precedence.
+7. Click "Start build" and monitor the deploy job.
 
 ## Build Environment
 

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -126,7 +126,7 @@ phases:
           for env in ${ENVIRONMENTS}; do
             time="${time}\n${phase}-${env} - $(date +%r) - started"
             tar -C build/${env} -cf build/${env}.tar.bz2 .
-            aws s3 cp --no-progress --acl public-read build/${env}.tar.bz2 s3://${S3_ARCHIVE_BUCKET}/cb-${COMMIT_HASH}/developer-portal-${env}.tar.bz2
+            aws s3 cp --no-progress --acl public-read build/${env}.tar.bz2 s3://${S3_ARCHIVE_BUCKET}/${COMMIT_HASH}/developer-portal-${env}.tar.bz2
           done
         fi
       # Check if we deploy to the review bucket

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -64,9 +64,9 @@ phases:
           done
         elif [[ ${COMMIT_HASH} ]]; then 
           # confirm that commit has an archived build
-          aws s3 ls s3://${S3_ARCHIVE_BUCKET}/cb-${COMMIT_HASH:0:7}/ || exit 1
+          aws s3 ls s3://${S3_ARCHIVE_BUCKET}/${COMMIT_HASH:0:7}/ || exit 1
           echo "Downloading assets for commit ${COMMIT_HASH}"
-          aws s3 sync --no-progress s3://${S3_ARCHIVE_BUCKET}/cb-${COMMIT_HASH:0:7}/ .
+          aws s3 sync --no-progress s3://${S3_ARCHIVE_BUCKET}/${COMMIT_HASH:0:7}/ .
         fi
       # Deploy environments
       - echo "Begining deployments to ${ENVIRONMENTS}"

--- a/cicd/buildspec-release.yml
+++ b/cicd/buildspec-release.yml
@@ -54,7 +54,7 @@ phases:
           exit 1
         fi
       - mkdir -p release
-      - aws s3 sync --no-progress s3://${S3_ARCHIVE_BUCKET}/cb-${COMMIT_HASH:0:7} release/.
+      - aws s3 sync --no-progress s3://${S3_ARCHIVE_BUCKET}/${COMMIT_HASH:0:7} release/.
       # Check that all files exist
       - |
         for env in ${ENVS}; do
@@ -64,17 +64,15 @@ phases:
           fi
         done
       # Create new tag
-      # The cb- prefix is used to test functionalty of CodeBuild without interfering with Jenkins
-      # the cb- prefix should be removed once we migrate releases to CodeBuild
-      - OLD_TAG=$(git tag --sort=-creatordate | grep cb- | head -1)
-      # Migration Code
-      #- OLD_TAG=$(git tag --sort=-creatordate | head -1)
+      # 'grep ^developer-portal' is necessary during the transition since a cb-developer-portal
+      # release might be most recent at the time of the cutover
+      - OLD_TAG=$(git tag --sort=-creatordate | grep ^developer-portal | head -1)
       - echo "Found ${OLD_TAG} - incrementing..."
       - NEW_TAG=$(increment.sh ${OLD_TAG})
       - echo "Creating ${NEW_TAG} release"
       - gh release create ${NEW_TAG}
       - echo "Uploading artifacts"
-      - VERSION=${NEW_TAG#"cb-developer-portal/v"}
+      - VERSION=${NEW_TAG#"developer-portal/v"}
       # Upload artifacts to release after adding version number to file.
       # gh tool utilizes # to define the display name for the uploaded asset
       # <file#display_name> i.e. developer-portal-dev-v0.0.1.tar.bz2#Developer_Portal_v0.0.1_dev.tar.bz2
@@ -86,12 +84,10 @@ phases:
           echo "${env} artifact uploaded"
         done
       # This is will kick off a a deployment to dev and staging deployments
-      # Temporarily deploying by commit during the transition, will switch back to release once
-      # CodeBuild controls the main release
       - |
         if [[ ${DEPLOY} == "true" ]]; then
           echo "Initiating build for ${NEW_TAG} (commit ${COMMIT_HASH})"
-          aws codebuild start-build --project-name developer-portal-deploy --environment-variables-override name=COMMIT_HASH,value=${COMMIT_HASH}
+          aws codebuild start-build --project-name developer-portal-deploy --environment-variables-override name=RELEASE,value=${NEW_TAG}
         fi
   post_build:
     commands:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:monitoring": "node scripts/test.js --projects=e2e.jest.config.js --testMatch='<rootDir>/src/App.e2e.ts'",
     "test:accessibility": "node scripts/test.js --projects=e2e.jest.config.js --testMatch='<rootDir>/src/**/?(*.)(accessibility).(j|t)s?(x)' --runInBand",
     "test:accessibility:ci": "node scripts/test.js --projects=e2e.jest.config.js --testMatch='<rootDir>/src/**/?(*.)(accessibility).(j|t)s?(x)' --ci --testResultsProcessor='./node_modules/jest-junit-reporter' --forceExit --runInBand",
-    "test:visual": "node scripts/test.js --projects=visual.jest.config.js --runInBand",
+    "test:visual": "node scripts/test.js --projects=visual.jest.config.js --runInBand --ci",
     "test:coverage": "node scripts/test.js --coverage "
   },
   "dependencies": {


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

does a few things in support of [API-3139](https://vajira.max.gov/browse/API-3139) to make CodeBuild control the main release and production deploy:

- removes the `cb-` prefix from the S3 key used in the CodeBuild archive command.
  - also adds a `jenkins-` prefix to the corresponding key in the Jenkins archive command. (worth keeping temporarily, or should we get rid of the Jenkins archive stage entirely?)
- removes the `cb-` prefix from the CodeBuild release tag.
- changes the CodeBuild deploy that's kicked off from the release job to use the release and not the archived commit as the deployment artifacts.

see https://github.com/department-of-veterans-affairs/devops/pull/8446 for changes to Jenkins release + deploy. at the moment, we're only commenting them out.

note that production deploys will happen manually, as currently happens with the `developer-portal-backend` and other apps. previously, the production deploy happened daily Mon-Fri at 11:30 Eastern (scheduled at 10:30).

also adding the `--ci` flag to the `npm run test:visual` command. thanks to @RockslideJr, @duganth-va, and @rtravitz for that catch. open to feedback on how to configure this one - it could go in the Makefile, or we could use the `CI="true"` environment variable in `buildspec-ci.yml`.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [n/a] Tests added or updated for change
- [ ] Docs updated
  - [n/a] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [n/a] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [n/a] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [n/a] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->

- is it worthwhile to continue archiving the Jenkins builds with the `jenkins-` prefix, or should we remove the Jenkins archive step entirely?
- preferences on where to add the CI config for `jest-image-snapshot`? what are people's preferences for updating snapshots at the moment?
- do we need to keep the `grep ^developer-portal` check on line 51 of the deploy job as a safeguard in case there are releases in some other format for whatever unseen reason, or should we take that out?