### PR TITLE
Change route for Claims Attributes API to Docserver

### DIFF
--- a/src/apiDefs/data/benefits.ts
+++ b/src/apiDefs/data/benefits.ts
@@ -61,7 +61,7 @@ const benefitsApis: APIDescription[] = [
     description: 'Improve claim routing',
     docSources: [
       {
-        openApiUrl: `${OPEN_API_SPEC_HOST}/services/claims-attributes/v1/docs/openapi.json`,
+        openApiUrl: `${OPEN_API_SPEC_HOST}/internal/docserver/api/claims-attributes/1/oas/latest`,
       },
     ],
     enabledByDefault: false,


### PR DESCRIPTION
### Description
This PR supports [API-4350](https://vajira.max.gov/browse/API-4350). It changes the documentation route for the Claims Attributes API from pulling straight from the provider to using the Docserver.
<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->
All checks N/A

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
