### PR TITLE
API-5390: Fix postcss-loader blocked version in dependabot version config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,9 @@ updates:
       # -------------------------
       # WEBPACK 5 RELATED IGNORES
       # -------------------------
-      # Version 5.0.0 depends on updating webpack to version 5
+      # Version 4+ depends on updating webpack to version 5
       - dependency-name: postcss-loader
-        versions: [5.x]
+        versions: [4.x]
       # Version 11.0.1 introduces breaking changes in Webpack build and is not able to load the
       # options of the loader during the build stage. This dependency can be updated after
       # postcss-loaders gets update to latest version


### PR DESCRIPTION
### [API-5471: Fix postcss-loader blocked version in dependabot version config](https://vajira.max.gov/browse/API-5471)
Current dependabot configuration is set to ignore version updates from postcss-loader from 4.2.0 to 5.0.0. Correct versions are 3.0.0 to 3.0.0+.

Currently we are getting dependabot version alerts that are blocked.

### Process
- [X] Tests added or updated for change
