### PR TITLE
API-4399: 'Overview' Button on News Page Doesn't Work

### DIFF
--- a/src/containers/News.test.tsx
+++ b/src/containers/News.test.tsx
@@ -31,7 +31,7 @@ describe('News', () => {
       expect(navLinks).toHaveLength(data.sections.length + 1);
 
       const overviewLink = getByRole(sideNav, 'link', { name: 'Overview' });
-      expect(overviewLink).toHaveAttribute('href', '/news');
+      expect(overviewLink).toHaveAttribute('href', '/news#header-halo');
 
       data.sections.forEach((dataSection: DataSection) => {
         const link = getByRole(sideNav, 'link', { name: dataSection.title });

--- a/src/containers/News.tsx
+++ b/src/containers/News.tsx
@@ -86,7 +86,7 @@ const News = (): JSX.Element => {
     <ContentWithNav
       nav={
         <>
-          <SideNavEntry key="all" exact to="/news" name="Overview" />
+          <SideNavEntry key="all" exact to="#header-halo" name="Overview" />
           {sections.map((section: NewsSection) => (
             <SideNavEntry key={section.id} to={`#${section.id}`} name={section.title} />
           ))}


### PR DESCRIPTION
### Description
Jira ticket [here](https://vajira.max.gov/browse/API-4399)

The page anchor for the Overview tab in the side nav was aiming at the page url instead of a targeted id. I grabbed the id associated with the top of the page and plugged it into the anchor method. 

### Process

Had to change the test to check for the anchor url

- [ x] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ x] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

Feedback is always nice
