### PR TITLE
API-5944 - Fix table css on pages with Swagger-UI documentation

### DIFF
--- a/src/containers/documentation/swaggerPlugins/StyleOverride.scss
+++ b/src/containers/documentation/swaggerPlugins/StyleOverride.scss
@@ -1,3 +1,6 @@
+@import '../../../styles/variables';
+@import '~@department-of-veterans-affairs/formation/sass/full';
+
 @mixin table-style {
   padding: 0;
   margin: 0;
@@ -7,12 +10,12 @@
   tr {
     td {
       padding: 1rem;
-      background-color: #EEEEEE;
+      background-color: #eeeeee;
       border: 1px solid #5b616b;
       border-top-style: none;
       border-bottom-style: none;
     }
-    &:last-child{
+    &:last-child {
       td {
         border-bottom: 1px solid #5b616b;
       }
@@ -20,7 +23,8 @@
   }
 }
 
-.opblock-section, .responses-wrapper {
+.opblock-section,
+.responses-wrapper {
   margin: 2em 2em 0;
   padding-bottom: 1em;
 }
@@ -33,7 +37,8 @@
   display: none;
 }
 
-.table-container, .responses-inner {
+.table-container,
+.responses-inner {
   padding: 1em 0 2em !important;
 }
 
@@ -43,7 +48,8 @@
     .opblock-section-header {
       padding: 0 !important;
       box-shadow: none !important;
-      .opblock-title, h4 {
+      .opblock-title,
+      h4 {
         font-size: 3rem !important;
       }
     }
@@ -51,22 +57,46 @@
       padding: 0;
       .parameters {
         @include table-style;
-        input, select {
+        input,
+        select {
           display: none;
         }
       }
     }
     .responses-inner {
       padding: 0;
-      .responses-table{
+      .responses-table {
         @include table-style;
         thead {
           .col_header {
             border: 1px solid #5b616b;
-            border-bottom: 1px solid rgba(59, 65, 81, .2) !important;
+            border-bottom: 1px solid rgba(59, 65, 81, 0.2) !important;
           }
         }
       }
+    }
+  }
+}
+.swagger-ui .renderedMarkdown {
+  @import '~uswds/src/stylesheets/elements/table';
+
+  table {
+    thead tr {
+      th {
+        color: $color-gray-dark;
+        font-family: $font-sans;
+        font-size: $base-font-size;
+        font-weight: $font-bold;
+      }
+
+      th,
+      td {
+        background-color: $color-gray-lightest;
+      }
+    }
+    tbody tr td:first-of-type {
+      padding: 1rem 1.5rem;
+      width: auto;
     }
   }
 }

--- a/src/containers/documentation/swaggerPlugins/StyleOverride.scss
+++ b/src/containers/documentation/swaggerPlugins/StyleOverride.scss
@@ -83,13 +83,13 @@
   table {
     thead tr {
       th {
+        background-color: $color-gray-lightest;
         color: $color-gray-dark;
         font-family: $font-sans;
         font-size: $base-font-size;
         font-weight: $font-bold;
       }
 
-      th,
       td {
         background-color: $color-gray-lightest;
       }


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-5944

Pages with html tables that are generated through their swagger docs were having their css collide with the tables within each endpoint's details accordion.

### Process

Confirm that the tables on these pages are displaying properly while those on the [auth docs](https://developer.va.gov/explore/authorization?api=claims) aren't affected.

https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current
https://developer.va.gov/explore/benefits/docs/claims?version=current

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

There shouldn't be any visual regressions failures because these 2 urls are not included in our limited testing set of swagger based pages. Do we want to add one of these to make sure they don't get adversely affected in a future push?