### PR TITLE
[API-5904] - Update Release Notes for ClaimsApi Endpoint Deprecations

### DIFF
--- a/src/content/apiDocs/benefits/claimsReleaseNotes.mdx
+++ b/src/content/apiDocs/benefits/claimsReleaseNotes.mdx
@@ -1,3 +1,14 @@
+### March 26, 2021
+
+* (v0 & v1) Deprecate "schema" endpoint for 526 form [#6289](https://github.com/department-of-veterans-affairs/vets-api/pull/6289)
+* (v0 & v1) Deprecate "schema" endpoint for 0966 form [#6289](https://github.com/department-of-veterans-affairs/vets-api/pull/6289)
+* (v0 & v1) Deprecate "schema" endpoint for 2122 form [#6289](https://github.com/department-of-veterans-affairs/vets-api/pull/6289)
+* (v0 & v1) Deprecate "validate" endpoint for 526 form [#6289](https://github.com/department-of-veterans-affairs/vets-api/pull/6289)
+* (v0 & v1) Deprecate "validate" endpoint for 0966 form [#6289](https://github.com/department-of-veterans-affairs/vets-api/pull/6289)
+* (v0 & v1) Deprecate "validate" endpoint for 2122 form [#6289](https://github.com/department-of-veterans-affairs/vets-api/pull/6289)
+
+---
+
 ### January 4, 2021
 
 * (v0 & v1) Write flashes to BGS when 526 claims are submitted for auto-establishment [#5248](https://github.com/department-of-veterans-affairs/vets-api/pull/5248)


### PR DESCRIPTION
### Description
Updates Release Notes to indicate that the ClaimsApi "schema" and "validate" endpoints are being deprecated.
[API-5094](https://vajira.max.gov/browse/API-5904)