### PR TITLE
Add env variable option for overwriting deactivation and deprecation dates

### DIFF
--- a/src/apiDefs/deprecated.test.ts
+++ b/src/apiDefs/deprecated.test.ts
@@ -18,10 +18,40 @@ describe('deprecated API module', () => {
     urlFragment: 'my_api',
     vaInternalOnly: false,
   };
+  let oldEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    oldEnv = process.env;
+    process.env = {
+      ...oldEnv,
+    };
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+  });
 
   describe('isApiDeprecated', () => {
     it('returns false if deactivationInfo is undefined', () => {
       expect(isApiDeprecated(apiValues)).toBe(false);
+    });
+
+    it('returns true if the FF is set', () => {
+      process.env = {
+        ...oldEnv,
+        'REACT_APP_MY_API_DEPRECATED': 'true',
+      };
+      const api: APIDescription = {
+        ...apiValues,
+        deactivationInfo: {
+          deactivationContent: UrgentCareDeprecationNotice,
+          deactivationDate: moment().add(2, 'month'),
+          deprecationContent: UrgentCareDeprecationNotice,
+          deprecationDate: moment().add(1, 'month'),
+        },
+      };
+
+      expect(isApiDeprecated(api)).toBe(true);
     });
 
     it('returns false if the deprecation date is in the future', () => {
@@ -67,6 +97,24 @@ describe('deprecated API module', () => {
   describe('isApiDeactivated', () => {
     it('returns false if deactivationInfo is undefined', () => {
       expect(isApiDeactivated(apiValues)).toBe(false);
+    });
+
+    it('returns true if the FF is set', () => {
+      process.env = {
+        ...oldEnv,
+        'REACT_APP_MY_API_DEACTIVATED': 'true',
+      };
+      const api: APIDescription = {
+        ...apiValues,
+        deactivationInfo: {
+          deactivationContent: UrgentCareDeprecationNotice,
+          deactivationDate: moment().add(2, 'month'),
+          deprecationContent: UrgentCareDeprecationNotice,
+          deprecationDate: moment().add(1, 'month'),
+        },
+      };
+
+      expect(isApiDeactivated(api)).toBe(true);
     });
 
     it('returns false if the API is not deprecated yet', () => {

--- a/src/apiDefs/deprecated.ts
+++ b/src/apiDefs/deprecated.ts
@@ -7,12 +7,24 @@ export const isApiDeprecated = (api: APIDescription): boolean => {
     return false;
   }
 
+  const deprecatedFF = process.env[`REACT_APP_${api.urlFragment.toUpperCase()}_DEPRECATED`];
+
+  if (deprecatedFF) {
+    return true;
+  }
+
   return moment().isAfter(api.deactivationInfo.deprecationDate);
 };
 
 export const isApiDeactivated = (api: APIDescription): boolean => {
   if (api.deactivationInfo === undefined) {
     return false;
+  }
+
+  const deactivatedFF = process.env[`REACT_APP_${api.urlFragment.toUpperCase()}_DEACTIVATED`];
+
+  if (deactivatedFF) {
+    return true;
   }
 
   return moment().isAfter(api.deactivationInfo.deactivationDate);


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

[API-2101](https://vajira.max.gov/browse/API-2101)
Adds in the option to set environment variables to overwrite deprecation and deactivation dates. This can be used to test deactivation or deprecation notifications in any environment by setting the env variable. It does still require that the deactivation or deprecation information (dates and content) be set.

The environment variables are in the form `REACT_APP_{key}_DEACTIVATED` and `REACT_APP_{key}_DEACTIVATED` where `{key}` is the api url fragment in all uppercase. (e.g `REACT_APP_CLAIMS_ATTRIBUTES_DEACTIVATED`)


### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [x] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues