### PR TITLE
API-4018: Move flag names to constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13948,7 +13948,7 @@
       "dependencies": {
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -18125,8 +18125,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         }
       }
@@ -18334,7 +18333,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -24183,7 +24182,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -28278,9 +28277,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -28671,7 +28670,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -30,6 +30,7 @@ import {
   PUBLISHING_PATH,
 } from './types/constants/paths';
 import { Apply } from './containers/apply/Apply';
+import { FLAG_SIGNUPS_ENABLED } from './types/constants';
 
 export const SiteRoutes: React.FunctionComponent = (): JSX.Element => {
   const flags = getFlags();
@@ -52,7 +53,7 @@ export const SiteRoutes: React.FunctionComponent = (): JSX.Element => {
         path="/apply"
         render={(): JSX.Element => (
           <Flag
-            name={['signups_enabled']}
+            name={[FLAG_SIGNUPS_ENABLED]}
             component={Apply}
             fallbackComponent={DisabledApplyForm}
           />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -5,6 +5,7 @@ import { HashLink } from 'react-router-hash-link';
 import { Banner, NavBar } from '../../components';
 import { Flag } from '../../flags';
 import { defaultFlexContainer, desktopOnly, mobileOnly } from '../../styles/vadsUtils';
+import { FLAG_SHOW_TESTING_NOTICE } from '../../types/constants';
 import VeteransCrisisLine from '../crisisLine/VeteransCrisisLine';
 import Search from '../search/Search';
 import TestingNotice from '../TestingNotice';
@@ -33,7 +34,7 @@ const Header = (): JSX.Element => {
    */
   return (
     <>
-      <Flag name={['show_testing_notice']}>
+      <Flag name={[FLAG_SHOW_TESTING_NOTICE]}>
         <TestingNotice />
       </Flag>
       <header

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { match as Match } from 'react-router';
 import { Link } from 'react-router-dom';
 
-import { FLAG_CONSUMER_DOCS } from '../../types/constants';
+import { FLAG_CATEGORIES, FLAG_CONSUMER_DOCS } from '../../types/constants';
 import {
   CONSUMER_PATH,
   PUBLISHING_EXPECTATIONS_PATH,
@@ -146,7 +146,7 @@ const NavBar = (props: NavBarProps): JSX.Element => {
                 Overview
               </SubNavEntry>
               {apiCategoryOrder.map(apiKey => (
-                <Flag name={['categories', apiKey]} key={apiKey}>
+                <Flag name={[FLAG_CATEGORIES, apiKey]} key={apiKey}>
                   <SubNavEntry
                     onClick={props.onMobileNavClose}
                     to={`/explore/${apiKey}`}

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -7,6 +7,7 @@ import padlockImg from '../assets/homepage-padlock.svg';
 import apiImg from '../assets/homepage-reliable-api.svg';
 import { CardLink, Hero } from '../components';
 import { Flag } from '../flags';
+import { FLAG_CATEGORIES } from '../types/constants';
 
 const leftColumnClasses = classNames(
   'medium-screen:vads-l-col--4',
@@ -63,7 +64,7 @@ const ApiList = (): JSX.Element => (
             {apiCategoryOrder.map((apiCategoryKey: string) => {
               const { name, content } = apiDefinitions[apiCategoryKey];
               return (
-                <Flag name={['categories', apiCategoryKey]} key={apiCategoryKey}>
+                <Flag name={[FLAG_CATEGORIES, apiCategoryKey]} key={apiCategoryKey}>
                   <CardLink name={`VA ${name}`} url={`/explore/${apiCategoryKey}`}>
                     {content.placardText}
                   </CardLink>

--- a/src/containers/documentation/ApiDocumentation.tsx
+++ b/src/containers/documentation/ApiDocumentation.tsx
@@ -8,7 +8,7 @@ import * as actions from '../../actions';
 import { APIDescription, ApiDescriptionPropType, APIDocSource } from '../../apiDefs/schema';
 import { Flag, useFlag } from '../../flags';
 import { history } from '../../store';
-import { FLAG_AUTH_DOCS_V2 } from '../../types/constants';
+import { FLAG_AUTH_DOCS_V2, FLAG_HOSTED_APIS } from '../../types/constants';
 import { SwaggerDocs } from './SwaggerDocs';
 
 import '../../../node_modules/react-tabs/style/react-tabs.scss';
@@ -34,9 +34,7 @@ const getInitialTabIndex = (searchQuery: string, docSources: APIDocSource[]): nu
 
   // Get doc source keys
   const hasKey = (source: APIDocSource): boolean => !!source.key;
-  const tabKeys = docSources
-    .filter(hasKey)
-    .map(source => source.key?.toLowerCase() ?? '');
+  const tabKeys = docSources.filter(hasKey).map(source => source.key?.toLowerCase() ?? '');
 
   // Return tab index
   const sourceTabIndex = tabKeys.findIndex(sourceKey => sourceKey === queryStringTab);
@@ -50,10 +48,7 @@ const ApiDocumentation = (props: ApiDocumentationProps): JSX.Element => {
    * Tab Index
    */
   const [tabIndex, setTabIndex] = React.useState(
-    getInitialTabIndex(
-      location.search,
-      apiDefinition.docSources,
-    ),
+    getInitialTabIndex(location.search, apiDefinition.docSources),
   );
 
   const onTabSelect = (selectedTabIndex: number): void => {
@@ -82,20 +77,19 @@ const ApiDocumentation = (props: ApiDocumentationProps): JSX.Element => {
    * RENDER
    */
   return (
-    <Flag name={['hosted_apis', apiDefinition.urlFragment]}>
-      {(apiDefinition.oAuth && authDocsV2) && (
+    <Flag name={[FLAG_HOSTED_APIS, apiDefinition.urlFragment]}>
+      {apiDefinition.oAuth && authDocsV2 && (
         <div role="region" aria-labelledby="oauth-info-heading" className="api-docs-oauth-link">
-          <h2 id="oauth-info-heading" className="usa-alert-heading">Authentication and Authorization</h2>
+          <h2 id="oauth-info-heading" className="usa-alert-heading">
+            Authentication and Authorization
+          </h2>
           <Link to={`/explore/authorization?api=${apiDefinition.urlFragment}`}>
             View our OAuth documentation
           </Link>
         </div>
       )}
       {apiDefinition.docSources.length === 1 ? (
-        <SwaggerDocs
-          docSource={apiDefinition.docSources[0]}
-          apiName={apiDefinition.urlFragment}
-        />
+        <SwaggerDocs docSource={apiDefinition.docSources[0]} apiName={apiDefinition.urlFragment} />
       ) : (
         <>
           {apiDefinition.multiOpenAPIIntro?.({})}

--- a/src/containers/documentation/ApiPage.tsx
+++ b/src/containers/documentation/ApiPage.tsx
@@ -12,6 +12,7 @@ import ExplorePage from '../../content/explorePage.mdx';
 import { Flag } from '../../flags';
 
 import { APINameParam } from '../../types';
+import { FLAG_API_ENABLED_PROPERTY } from '../../types/constants';
 import ApiDocumentation from './ApiDocumentation';
 import ApiNotFoundPage from './ApiNotFoundPage';
 
@@ -66,30 +67,26 @@ const ApiPage = (): JSX.Element => {
   }
 
   return (
-    <Flag name={['enabled', api.urlFragment]} fallbackRender={(): JSX.Element => <ExplorePage />}>
+    <Flag
+      name={[FLAG_API_ENABLED_PROPERTY, api.urlFragment]}
+      fallbackRender={(): JSX.Element => <ExplorePage />}
+    >
       <Helmet>
         <title>{api.name} Documentation</title>
       </Helmet>
       <PageHeader halo={category.name} header={api.name} />
-      {api.veteranRedirect &&
+      {api.veteranRedirect && (
         <AlertBox
           status="info"
           key={api.urlFragment}
           className={classNames('vads-u-margin-bottom--2', 'vads-u-padding-y--1')}
         >
           {api.veteranRedirect.message}&nbsp;
-          <a href={api.veteranRedirect.linkUrl}>
-            {api.veteranRedirect.linkText}
-          </a>
-          .
-        </AlertBox>}
-      <DeactivationMessage api={api} />
-      {!isApiDeactivated(api) && (
-        <ApiDocumentation
-          apiDefinition={api}
-          location={location}
-        />
+          <a href={api.veteranRedirect.linkUrl}>{api.veteranRedirect.linkText}</a>.
+        </AlertBox>
       )}
+      <DeactivationMessage api={api} />
+      {!isApiDeactivated(api) && <ApiDocumentation apiDefinition={api} location={location} />}
     </Flag>
   );
 };

--- a/src/containers/documentation/CategoryPage.tsx
+++ b/src/containers/documentation/CategoryPage.tsx
@@ -8,7 +8,7 @@ import { APIDescription } from '../../apiDefs/schema';
 import { AuthorizationCard, CardLink, OnlyTags, PageHeader } from '../../components';
 import { defaultFlexContainer } from '../../styles/vadsUtils';
 import { APINameParam } from '../../types';
-import { FLAG_AUTH_DOCS_V2, PAGE_HEADER_ID } from '../../types/constants';
+import { FLAG_AUTH_DOCS_V2, FLAG_HOSTED_APIS, PAGE_HEADER_ID } from '../../types/constants';
 
 const CategoryPage = (): JSX.Element => {
   const authDocsV2 = useFlag([FLAG_AUTH_DOCS_V2]);
@@ -25,15 +25,13 @@ const CategoryPage = (): JSX.Element => {
     const apiCards = apis.map((apiDesc: APIDescription) => {
       const { description, name, urlFragment, vaInternalOnly, trustedPartnerOnly } = apiDesc;
       return (
-        <Flag key={name} name={['hosted_apis', urlFragment]}>
+        <Flag key={name} name={[FLAG_HOSTED_APIS, urlFragment]}>
           <CardLink
             name={name}
             subhead={
               vaInternalOnly || trustedPartnerOnly ? (
                 <OnlyTags {...{ trustedPartnerOnly, vaInternalOnly }} />
-              ) : (
-                undefined
-              )
+              ) : undefined
             }
             url={`/explore/${apiCategoryKey}/docs/${urlFragment}`}
           >
@@ -68,14 +66,12 @@ const CategoryPage = (): JSX.Element => {
       {cardSection}
       <div className="vads-u-width--full">{overview({})}</div>
       <hr />
-      {veteranRedirect &&
+      {veteranRedirect && (
         <AlertBox status="info" key={apiCategoryKey}>
           {veteranRedirect.message}&nbsp;
-          <a href={veteranRedirect.linkUrl}>
-            {veteranRedirect.linkText}
-          </a>
-          .
-        </AlertBox>}
+          <a href={veteranRedirect.linkUrl}>{veteranRedirect.linkText}</a>.
+        </AlertBox>
+      )}
     </div>
   );
 };

--- a/src/containers/documentation/DocumentationOverview.tsx
+++ b/src/containers/documentation/DocumentationOverview.tsx
@@ -4,7 +4,7 @@ import { getApiCategoryOrder, getApiDefinitions } from '../../apiDefs/query';
 import { AuthorizationCard, CardLink, PageHeader } from '../../components';
 import { Flag } from '../../flags';
 import { defaultFlexContainer } from '../../styles/vadsUtils';
-import { FLAG_AUTH_DOCS_V2 } from '../../types/constants';
+import { FLAG_AUTH_DOCS_V2, FLAG_CATEGORIES } from '../../types/constants';
 
 const DocumentationOverview = (): JSX.Element => {
   const apiDefinitions = getApiDefinitions();
@@ -26,7 +26,7 @@ const DocumentationOverview = (): JSX.Element => {
         {apiCategoryOrder.map((apiCategoryKey: string) => {
           const { name, content } = apiDefinitions[apiCategoryKey];
           return (
-            <Flag name={['categories', apiCategoryKey]} key={apiCategoryKey}>
+            <Flag name={[FLAG_CATEGORIES, apiCategoryKey]} key={apiCategoryKey}>
               <CardLink name={name} url={`/explore/${apiCategoryKey}`}>
                 {content.shortDescription}
               </CardLink>

--- a/src/containers/documentation/DocumentationRoot.tsx
+++ b/src/containers/documentation/DocumentationRoot.tsx
@@ -7,7 +7,12 @@ import { APICategory, APIDescription } from '../../apiDefs/schema';
 import { ContentWithNav, SideNavEntry } from '../../components';
 import { Flag, useFlag } from '../../flags';
 import { APINameParam } from '../../types';
-import { CURRENT_VERSION_IDENTIFIER, FLAG_AUTH_DOCS_V2 } from '../../types/constants';
+import {
+  CURRENT_VERSION_IDENTIFIER,
+  FLAG_AUTH_DOCS_V2,
+  FLAG_CATEGORIES,
+  FLAG_HOSTED_APIS,
+} from '../../types/constants';
 import ApiPage from './ApiPage';
 import { AuthorizationDocs } from './AuthorizationDocs';
 import { AuthorizationDocsLegacy } from './AuthorizationDocsLegacy';
@@ -18,13 +23,11 @@ import QuickstartPage from './QuickstartPage';
 import './Documentation.scss';
 
 const SideNavApiEntry = (apiCategoryKey: string, api: APIDescription): JSX.Element => (
-  <Flag key={api.urlFragment} name={['hosted_apis', api.urlFragment]}>
+  <Flag key={api.urlFragment} name={[FLAG_HOSTED_APIS, api.urlFragment]}>
     <SideNavEntry
       key={api.urlFragment}
       exact
-      to={`/explore/${apiCategoryKey}/docs/${
-        api.urlFragment
-      }?version=${CURRENT_VERSION_IDENTIFIER}`}
+      to={`/explore/${apiCategoryKey}/docs/${api.urlFragment}?version=${CURRENT_VERSION_IDENTIFIER}`}
       name={
         <>
           {api.name}
@@ -79,7 +82,7 @@ const ExploreSideNav = (): JSX.Element => {
       {apiCategoryOrder.map((categoryKey: string) => {
         const apiCategory: APICategory = apiDefinitions[categoryKey];
         return (
-          <Flag name={['categories', categoryKey]} key={categoryKey}>
+          <Flag name={[FLAG_CATEGORIES, categoryKey]} key={categoryKey}>
             <SideNavEntry
               to={`/explore/${categoryKey}`}
               id={`side-nav-category-link-${categoryKey}`}
@@ -135,8 +138,16 @@ const DocumentationRoot = (): JSX.Element => {
           {oldRouteToNew.map(routes => (
             <Redirect key={routes.from} exact from={routes.from} to={routes.to} />
           ))}
-          {authDocsV2 && <Route path="/explore/authorization" component={AuthorizationDocs} exact />}
-          {authDocsV2 && <Redirect exact from="/explore/verification/docs/authorization" to="/explore/authorization?api=veteran_verification" />}
+          {authDocsV2 && (
+            <Route path="/explore/authorization" component={AuthorizationDocs} exact />
+          )}
+          {authDocsV2 && (
+            <Redirect
+              exact
+              from="/explore/verification/docs/authorization"
+              to="/explore/authorization?api=veteran_verification"
+            />
+          )}
           {!shouldRouteCategory && <Redirect from="/explore/:apiCategoryKey" to="/404" />}
           <Route exact path="/explore/" component={DocumentationOverview} />
           <Route exact path="/explore/:apiCategoryKey" component={CategoryPage} />

--- a/src/containers/releaseNotes/CategoryReleaseNotes.tsx
+++ b/src/containers/releaseNotes/CategoryReleaseNotes.tsx
@@ -3,7 +3,11 @@ import classNames from 'classnames';
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import { Redirect, useParams } from 'react-router';
-import { PAGE_HEADER_AND_HALO_ID } from '../../types/constants';
+import {
+  PAGE_HEADER_AND_HALO_ID,
+  FLAG_API_ENABLED_PROPERTY,
+  FLAG_HOSTED_APIS,
+} from '../../types/constants';
 
 import { getDeactivatedCategory, isApiDeactivated } from '../../apiDefs/deprecated';
 import { getApiDefinitions } from '../../apiDefs/query';
@@ -43,9 +47,7 @@ const ReleaseNotesCardLinks: React.FunctionComponent<ReleaseNotesCardLinksProps>
               subhead={
                 vaInternalOnly || trustedPartnerOnly ? (
                   <OnlyTags {...{ trustedPartnerOnly, vaInternalOnly }} />
-                ) : (
-                  undefined
-                )
+                ) : undefined
               }
               url={`/release-notes/${categoryKey}#${dashUrlFragment}`}
             >
@@ -127,7 +129,7 @@ export const CategoryReleaseNotes = (): JSX.Element => {
     <ReleaseNotesCollection
       categoryKey={apiCategoryKey}
       apiCategory={categories[apiCategoryKey]}
-      apiFlagName="hosted_apis"
+      apiFlagName={FLAG_HOSTED_APIS}
     />
   );
 };
@@ -136,7 +138,7 @@ export const DeactivatedReleaseNotes = (): JSX.Element => (
   <ReleaseNotesCollection
     categoryKey="deactivated"
     apiCategory={getDeactivatedCategory()}
-    apiFlagName="enabled"
+    apiFlagName={FLAG_API_ENABLED_PROPERTY}
     alertText="This is a repository for deactivated APIs and related documentation and release notes."
   />
 );

--- a/src/containers/releaseNotes/ReleaseNotes.tsx
+++ b/src/containers/releaseNotes/ReleaseNotes.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { PAGE_HEADER_AND_HALO_ID } from '../../types/constants';
+import { FLAG_CATEGORIES, PAGE_HEADER_AND_HALO_ID } from '../../types/constants';
 import {
   RELEASE_NOTES_CATEGORY_PATH,
   RELEASE_NOTES_DEACTIVATED_PATH,
@@ -61,7 +61,7 @@ const SideNavCategoryEntry = (props: SideNavCategoryEntryProps): JSX.Element => 
   );
 
   return (
-    <Flag name={['categories', categoryKey]} key={categoryKey}>
+    <Flag name={[FLAG_CATEGORIES, categoryKey]} key={categoryKey}>
       <SideNavEntry to={`/release-notes/${categoryKey}`} name={apiCategory.name}>
         {apis.length > 1 &&
           apis.map(api => (

--- a/src/containers/releaseNotes/ReleaseNotesOverview.tsx
+++ b/src/containers/releaseNotes/ReleaseNotesOverview.tsx
@@ -5,6 +5,7 @@ import { getApiCategoryOrder, getApiDefinitions } from '../../apiDefs/query';
 import { CardLink, PageHeader } from '../../components';
 import { Flag } from '../../flags';
 import { defaultFlexContainer } from '../../styles/vadsUtils';
+import { FLAG_CATEGORIES } from '../../types/constants';
 
 const ReleaseNotesOverview = (): JSX.Element => {
   const apiDefs = getApiDefinitions();
@@ -33,7 +34,7 @@ const ReleaseNotesOverview = (): JSX.Element => {
         {getApiCategoryOrder().map((apiCategoryKey: string) => {
           const { name, content } = apiDefs[apiCategoryKey];
           return (
-            <Flag name={['categories', apiCategoryKey]} key={apiCategoryKey}>
+            <Flag name={[FLAG_CATEGORIES, apiCategoryKey]} key={apiCategoryKey}>
               <CardLink name={name} url={`/release-notes/${apiCategoryKey}`}>
                 {content.shortDescription}
               </CardLink>

--- a/src/types/constants/index.ts
+++ b/src/types/constants/index.ts
@@ -6,8 +6,9 @@ export const CURRENT_VERSION_IDENTIFIER = 'current';
 export const DEFAULT_OAUTH_API_SELECTION = 'claims';
 export const OPEN_API_SPEC_HOST: string = process.env.REACT_APP_VETSGOV_SWAGGER_API ?? '';
 
-const BACKEND_BASE_URL = `${process.env.REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL ??
-  ''}/internal/developer-portal/public`;
+const BACKEND_BASE_URL = `${
+  process.env.REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL ?? ''
+}/internal/developer-portal/public`;
 export const APPLY_URL = `${BACKEND_BASE_URL}/developer_application`;
 export const CONTACT_US_URL = `${BACKEND_BASE_URL}/contact-us`;
 
@@ -26,5 +27,11 @@ export const APPLY_STANDARD_APIS = ['benefits', 'facilities', 'vaForms', 'confir
 export const APPLY_OAUTH_APIS = ['claims', 'communityCare', 'health', 'verification'];
 export const PAGE_HEADER_ID = 'page-header';
 export const PAGE_HEADER_AND_HALO_ID = 'header-halo';
+
+export const FLAG_API_ENABLED_PROPERTY = 'enabled';
+export const FLAG_CATEGORIES = 'categories';
 export const FLAG_CONSUMER_DOCS = 'consumer_docs';
+export const FLAG_HOSTED_APIS = 'hosted_apis';
+export const FLAG_SHOW_TESTING_NOTICE = 'show_testing_notice';
+export const FLAG_SIGNUPS_ENABLED = 'signups_enabled';
 export const FLAG_AUTH_DOCS_V2 = 'auth_docs_v2';


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-4018

The goal here is to move all flag names to use constant values to make any future refactoring much easier and prevent accidental changes that break existing flags.

### Process

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback
