### PR TITLE
API-6498: Release note for Limited Consent Schema correction

### DIFF
--- a/src/content/apiDocs/benefits/claimsReleaseNotes.mdx
+++ b/src/content/apiDocs/benefits/claimsReleaseNotes.mdx
@@ -1,3 +1,7 @@
+### May 3, 2021
+
+* (v0 & v1) Fixed documentation to properly define consentLimits for a POST 2122 submission [#6728](https://github.com/department-of-veterans-affairs/vets-api/pull/6728)
+
 ### April 22, 2021
 
 * (v1) "/forms/2122/active" now returns current and previous POA regardless of prior submissions to Lighthouse Claims API [#6621](https://github.com/department-of-veterans-affairs/vets-api/pull/6621)


### PR DESCRIPTION
### Description
Adds a release note to ensure consumers are made aware of a change in our documentation to reflect the current implementation around 2122 submission.

Requires the PR making this change to be deployed next Monday:
https://github.com/department-of-veterans-affairs/vets-api/pull/6728
otherwise the date defined in this pr will need to change