### PR TITLE
Resolve dns-packet to 5.2.2 due to npm audit alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11314,16 +11314,6 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
-    "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
-      "dev": true,
-      "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "dns-txt": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
@@ -19761,6 +19751,17 @@
       "requires": {
         "dns-packet": "^1.3.1",
         "thunky": "^1.0.2"
+      },
+      "dependencies": {
+        "dns-packet": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.2.tgz",
+          "integrity": "sha512-sQN+vLwC3PvOXiCH/oHcdzML2opFeIdVh8gjjMZrM45n4dR80QF6o3AzInQy6F9Eoc0VJYog4JpQTilt4RFLYQ==",
+          "dev": true,
+          "requires": {
+            "ip": "^1.1.5"
+          }
+        }
       }
     },
     "multicast-dns-service-types": {

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "webpack-manifest-plugin": "^3.1.1"
   },
   "resolutions": {
+    "dns-packet": "5.2.2",
     "husky": "6.0.0",
     "trim": "1.0.1"
   },


### PR DESCRIPTION
### Description

Updates `dns-packet` to resolve a vulnerability and allow builds to continue.

### Process

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback
