### PR TITLE
Don't send internal only details when api is not internal only

### DIFF
--- a/src/containers/support/ContactUsForm/ContactUsForm.test.tsx
+++ b/src/containers/support/ContactUsForm/ContactUsForm.test.tsx
@@ -204,16 +204,46 @@ describe('SupportContactUsFormPublishing', () => {
         });
 
         describe('submitting the form', () => {
-          beforeEach(async () => {
+          it('sends the values', async () => {
             userEvent.click(screen.getByRole('button', { name: 'Submit' }));
             expect(await screen.findByRole('button', { name: 'Sending...' })).toBeInTheDocument();
-          });
-          it('sends the values', async () => {
             expect(jsonSpy).toHaveBeenCalledWith({
               apiDescription: 'www.api.com',
               apiDetails: 'It takes the ring to mordor',
               apiInternalOnly: true,
               apiInternalOnlyDetails: 'The enemy has spies everywhere',
+              apiOtherInfo: 'No',
+              email: 'fbag@bagend.com',
+              firstName: 'Frodo',
+              lastName: 'Baggins',
+              organization: '',
+              type: 'PUBLISHING',
+            });
+            await waitFor(() => {
+              expect(mockMakeRequest).toHaveBeenCalledWith('http://fake.va.gov/internal/developer-portal/public/contact-us', {
+                body: expect.stringContaining('\"email\":\"fbag@bagend.com\"') as unknown,
+                headers: {
+                  accept: 'application/json',
+                  'content-type': 'application/json',
+                },
+                method: 'POST',
+              }, { responseType: 'TEXT' });
+            });
+            expect(mockOnSuccess).toHaveBeenCalled();
+            expect(await screen.findByRole('button', { name: 'Submit' })).toBeInTheDocument();
+          });
+
+          it('does not send api internal only details if the api is not internal only', async () => {
+            userEvent.click(screen.getByRole('radio', { name: 'No' }));
+            await waitFor(() => {
+              expect(screen.queryByRole('textbox', { name: /Tell us more about why the API needs to be restricted to internal VA use./ })).not.toBeInTheDocument();
+            });
+            userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+            expect(await screen.findByRole('button', { name: 'Sending...' })).toBeInTheDocument();
+            expect(jsonSpy).toHaveBeenCalledWith({
+              apiDescription: 'www.api.com',
+              apiDetails: 'It takes the ring to mordor',
+              apiInternalOnly: false,
               apiOtherInfo: 'No',
               email: 'fbag@bagend.com',
               firstName: 'Frodo',

--- a/src/containers/support/ContactUsForm/ContactUsForm.tsx
+++ b/src/containers/support/ContactUsForm/ContactUsForm.tsx
@@ -34,15 +34,21 @@ const processedData = (values: ContactUsFormState): SubmissionData => {
       type: values.type,
     };
   } else {
-    return {
+    const isInternalOnly = values.apiInternalOnly === 'yes';
+    const data: SubmissionData = {
       ...contactFormData,
       apiDescription: values.apiDescription ?? '',
       apiDetails: values.apiDetails,
-      apiInternalOnly: values.apiInternalOnly === 'yes',
-      apiInternalOnlyDetails: values.apiInternalOnlyDetails,
+      apiInternalOnly: isInternalOnly,
       apiOtherInfo: values.apiOtherInfo ?? '',
       type: values.type,
     };
+
+    if (isInternalOnly) {
+      data.apiInternalOnlyDetails = values.apiInternalOnlyDetails;
+    }
+
+    return data;
   }
 };
 

--- a/src/types/contactUsForm.ts
+++ b/src/types/contactUsForm.ts
@@ -39,7 +39,7 @@ type PublishingSubmissionData = {
   apiDetails: string;
   apiDescription: string;
   apiInternalOnly: boolean;
-  apiInternalOnlyDetails: string;
+  apiInternalOnlyDetails?: string;
   apiOtherInfo: string;
 } & ContactDetailsFormData;
 


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

This fixes an integration issue between the form and the backend. If the internal only radio button was set to No, the front end would still send whatever it had for the internal only details.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [x] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues
