### PR TITLE
Fix overflow bug in the curl generator

### DIFF
--- a/src/components/codeWrapper/CodeWrapper.scss
+++ b/src/components/codeWrapper/CodeWrapper.scss
@@ -5,4 +5,8 @@
     margin: 0;
     overflow: visible;
   }
+
+  code {
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

The bearer tokens for OAuth are very long, resulting in an overflow on the curl generator. This fixes an issue where the token/copy-paste button were pushed very far to the right, requiring a lot of scrolling.

**Before**
<img width="691" alt="Screen Shot 2021-06-07 at 6 20 28 PM" src="https://user-images.githubusercontent.com/13280995/121100192-e97e1500-c7be-11eb-9f60-a407c8846485.png">


**After**
<img width="685" alt="Screen Shot 2021-06-07 at 6 19 13 PM" src="https://user-images.githubusercontent.com/13280995/121100156-da976280-c7be-11eb-8b4e-a42e7e3b8c3f.png">


### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
