### PR TITLE
API-7870 - Create build.json on deploy with build specs

### DIFF
--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -85,6 +85,15 @@ phases:
           S3_BUCKET=S3_${u_env}_BUCKET 
           mkdir -p ${env}
           tar xf developer-portal-${env}.tar.bz2 -C ${env} || exit 1
+          # add deploy.json file with deployment data
+          date > ./current-date
+          echo '{' > ${env}/deploy.json
+          echo "  \"environment\": \"${env}\"," >> ${env}/deploy.json
+          echo "  \"date\": \"$( cat current-date )\"," >> ${env}/deploy.json
+          echo "  \"release\": \"${RELEASE}\"," >> ${env}/deploy.json
+          echo "  \"commit\": \"${COMMIT_HASH:0:7}\"" >> ${env}/deploy.json
+          echo '}' >> ${env}/deploy.json
+          rm ./current-date
           # eval is used for variable subsitution.
           eval aws s3 cp --recursive --no-progress --acl public-read ${env}/ s3://\${$S3_BUCKET}/ || exit 1
           # need to run sync after cp because (1) sync isn't very good at telling when updates have occurred

--- a/cicd/buildspec-review-deploy.yml
+++ b/cicd/buildspec-review-deploy.yml
@@ -66,17 +66,10 @@ phases:
       # Create the required dot files prior to build for proper deployment to review bucket
       - |
         for env in ${ENVIRONMENTS}; do
-          date > ./current-date
-          echo '{' > ${env}/deploy.json
-          echo "  \"environment\": \"${env}\"," >> ${env}/deploy.json
-          echo "  \"date\": \"$( cat current-date )\"," >> ${env}/deploy.json
-          echo "  \"commit\": \"${COMMIT_HASH:0:7}\"" >> ${env}/deploy.json
-          echo '}' >> ${env}/deploy.json
-          rm ./current-date
-          cat <<EOF > .env.${env}.local
-          PUBLIC_URL=/${S3_REVIEW_BUCKET}/${COMMIT_HASH}/${env}
-          REACT_APP_SENTRY_DSN=${PREVIEW_SENTRY_DSN}
-          EOF
+        cat <<EOF > .env.${env}.local
+        PUBLIC_URL=/${S3_REVIEW_BUCKET}/${COMMIT_HASH}/${env}
+        REACT_APP_SENTRY_DSN=${PREVIEW_SENTRY_DSN}
+        EOF
         done
       - make build
   build:
@@ -87,6 +80,17 @@ phases:
         for env in ${ENVIRONMENTS}; do
           make build_app ENVIRONMENT=${env} || exit 1
           links="${links} - [${env}](https://s3-us-gov-west-1.amazonaws.com/${S3_REVIEW_BUCKET}/${COMMIT_HASH}/${env}/index.html) <br>"
+        done
+      # Create deploy.json per environment
+      - |
+        for env in ${ENVIRONMENTS}; do
+          date > ./current-date
+          echo '{' > build/${env}/deploy.json
+          echo "  \"environment\": \"${env}\"," >> build/${env}/deploy.json
+          echo "  \"date\": \"$( cat current-date )\"," >> build/${env}/deploy.json
+          echo "  \"commit\": \"${COMMIT_HASH:0:7}\"" >> build/${env}/deploy.json
+          echo '}' >> build/${env}/deploy.json
+          rm ./current-date
         done
       # Deploy To s3 review bucket
       - aws s3 sync --no-progress --acl public-read build/ s3://${S3_REVIEW_BUCKET}/${COMMIT_HASH}/

--- a/cicd/buildspec-review-deploy.yml
+++ b/cicd/buildspec-review-deploy.yml
@@ -66,10 +66,17 @@ phases:
       # Create the required dot files prior to build for proper deployment to review bucket
       - |
         for env in ${ENVIRONMENTS}; do
-        cat <<EOF > .env.${env}.local
-        PUBLIC_URL=/${S3_REVIEW_BUCKET}/${COMMIT_HASH}/${env}
-        REACT_APP_SENTRY_DSN=${PREVIEW_SENTRY_DSN}
-        EOF
+          date > ./current-date
+          echo '{' > ${env}/deploy.json
+          echo "  \"environment\": \"${env}\"," >> ${env}/deploy.json
+          echo "  \"date\": \"$( cat current-date )\"," >> ${env}/deploy.json
+          echo "  \"commit\": \"${COMMIT_HASH:0:7}\"" >> ${env}/deploy.json
+          echo '}' >> ${env}/deploy.json
+          rm ./current-date
+          cat <<EOF > .env.${env}.local
+          PUBLIC_URL=/${S3_REVIEW_BUCKET}/${COMMIT_HASH}/${env}
+          REACT_APP_SENTRY_DSN=${PREVIEW_SENTRY_DSN}
+          EOF
         done
       - make build
   build:
@@ -84,5 +91,5 @@ phases:
       # Deploy To s3 review bucket
       - aws s3 sync --no-progress --acl public-read build/ s3://${S3_REVIEW_BUCKET}/${COMMIT_HASH}/
       - |
-          comment="these changes have been deployed to an s3 bucket. a build for each environment is available: <br><br> ${links} <br> due to s3 website hosting limitations in govcloud you need to first navigate to index.html explicitly."
+        comment="these changes have been deployed to an s3 bucket. a build for each environment is available: <br><br> ${links} <br> due to s3 website hosting limitations in govcloud you need to first navigate to index.html explicitly."
       - gh pr comment ${PRNUM} --body "${comment}"


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-7870

This will create a new file at `/deploy.json` that includes current hash, environment, date of deploy and release version in each environment.

### Process

Wait for the deploy job to finish and check for the file.

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

