### PR TITLE
API-7959 Update Address Validation metadata url to S3

### DIFF
--- a/src/apiDefs/data/verification.ts
+++ b/src/apiDefs/data/verification.ts
@@ -11,6 +11,7 @@ const verificationApis: APIDescription[] = [
     description: 'Provides methods to standardize and validate addresses.',
     docSources: [
       {
+        metadataUrl: `${OPEN_API_SPEC_HOST}/internal/docs/address-validation/metadata.json`,
         openApiUrl: `${OPEN_API_SPEC_HOST}/internal/docs/address-validation/v1/openapi.json`,
       },
     ],


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

[API-7959](https://vajira.max.gov/browse/API-7959)
The metadata url is used to define the need for a seperate version display. Address Validation now has multiple versions and a need for the metadata url. Quokka has deemed it prudent to claim ownership of the metadata because we are modifying each OAS that is served to have relevant pathing, servers, and security. Since we have knowledge of each API and their versions, it makes sense for the Docserver to generate such metadata. This is a manual attempt to prove out the concept.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
