### PR TITLE
Api 7950/change curl to use oas

### DIFF
--- a/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
@@ -70,13 +70,11 @@ const testCurlText = async (
 };
 
 const renderDecisionReviews = (): void => {
-  const decisionReviewSys = SwaggerUI({
+  SwaggerUI({
     dom_id: '#mount-decision-reviews',
     plugins: [SwaggerPlugins(() => false)],
     spec: decisionReviews,
   }) as System;
-  // test that the form is sensitive to version number
-  decisionReviewSys.versionActions.setApiVersion('1');
 };
 
 const renderFHIRR4 = (): void => {

--- a/src/containers/documentation/swaggerPlugins/CurlForm.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.tsx
@@ -33,6 +33,7 @@ export interface CurlFormState {
   params: Parameter[];
   requestBodyProperties: Schema[];
   paramValues: { [propertyName: string]: string };
+  version: undefined | string;
 }
 
 export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
@@ -46,11 +47,13 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
       paramValues: {},
       params: this.props.operation.parameters ?? [],
       requestBodyProperties,
+      version: undefined as undefined | string,
     };
 
     if (!this.isSwagger2() && this.requirementsMet()) {
       const spec: OpenAPISpecV3 = this.jsonSpec() as OpenAPISpecV3;
       state.env = spec.servers[0].url;
+      state.version = spec.servers[0].variables?.version?.default ?? 'v0';
     }
 
     state.params.forEach((parameter: Parameter) => {
@@ -154,7 +157,7 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
       const version = this.props.system.versionSelectors.majorVersion();
       options.server = this.state.env;
       options.serverVariables = {
-        version: `v${version}`,
+        version: version ? `v${version}` : this.state.version,
       };
     }
     options.spec = spec;

--- a/src/containers/documentation/swaggerPlugins/VersionSelector.test.ts
+++ b/src/containers/documentation/swaggerPlugins/VersionSelector.test.ts
@@ -23,9 +23,9 @@ describe('VersionSelector', () => {
       expect(VersionSelector.selectors.majorVersion(state)).toBe('1');
     });
 
-    it('returns 0 when apiVersion exists does not exist in state', () => {
+    it('returns empty when apiVersion exists does not exist in state', () => {
       const state = Map<string, string>({ apiName: 'claims' });
-      expect(VersionSelector.selectors.majorVersion(state)).toBe('0');
+      expect(VersionSelector.selectors.majorVersion(state)).toBe('');
     });
   });
 

--- a/src/containers/documentation/swaggerPlugins/VersionSelector.ts
+++ b/src/containers/documentation/swaggerPlugins/VersionSelector.ts
@@ -9,7 +9,7 @@ export const VersionSelector = {
     apiVersion: (state: Map<string, unknown>): string => state.get('apiVersion') as string,
     majorVersion: createSelector(
       apiVersion,
-      (version: string): string => (version ? version.substring(0, 1) : '0'),
+      (version: string): string => (version ? version.substring(0, 1) : ''),
     ),
     versionMetadata: (state: Map<string, unknown>): VersionMetadata[] | null =>
       state.get('versionMetadata') as VersionMetadata[] | null,

--- a/src/types/swagger-client.d.ts
+++ b/src/types/swagger-client.d.ts
@@ -43,6 +43,11 @@ declare module 'swagger-client' {
   export interface Server {
     url: string;
     description: string;
+    variables?: {
+      version?: {
+        default: string;
+      };
+    };
   }
 
   export type SecurityRequirement = Array<{ [schemeName: string]: string[] }>;


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

[API-7950](https://vajira.max.gov/browse/API-7950)
Change logic of the cURL form generator to use the metadata url or fallback to OAS as a default

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [x] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
