### PR TITLE
Remove root from DockerFile for Fortify Scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,7 @@ RUN mkdir ~/.npm-global && npm config set prefix '~/.npm-global' && export PATH=
 RUN npm install -g npm
 RUN npm install -g @sentry/cli
 
-COPY package.json package-lock.json ./
-
-# Add write permission to package-lock.json so npm resolutions can set the correct dependency version
-USER root
-RUN chmod 666 package-lock.json
-USER jenkins
+COPY --chown=jenkins:jenkins package.json package-lock.json ./
 
 RUN npm install
 


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-8095

Simply change a COPY command's default file ownership to avoid needing to become root.

### Process

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback
