### PR TITLE
Create demo preparation page in consumer onboarding docs

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -13,7 +13,7 @@ const envVars = [
   'BROWSER=false',
 ];
 
-if(!process.env.TEST_HOST) {
+if (!process.env.TEST_HOST) {
   puppeteerConfig.server = {
     command: `${envVars.join(' ')} npm run start`,
     protocol: 'http',

--- a/src/containers/consumerOnboarding/ConsumerOnboardingRoot.tsx
+++ b/src/containers/consumerOnboarding/ConsumerOnboardingRoot.tsx
@@ -9,6 +9,7 @@ import {
   CONSUMER_PROD_PATH,
   CONSUMER_SANDBOX_PATH,
 } from '../../types/constants/paths';
+import DemoPrep from './DemoPrep';
 import OnboardingOverview from './OnboardingOverview';
 
 const ConsumerOnboardingRoot = (): JSX.Element => (
@@ -25,6 +26,7 @@ const ConsumerOnboardingRoot = (): JSX.Element => (
     content={
       <Switch>
         <Route exact path={CONSUMER_PATH} component={OnboardingOverview} />
+        <Route path={CONSUMER_DEMO_PATH} component={DemoPrep} />
       </Switch>
     }
     navAriaLabel="Consumer Onboarding Page Nav"

--- a/src/containers/consumerOnboarding/DemoPrep.scss
+++ b/src/containers/consumerOnboarding/DemoPrep.scss
@@ -1,0 +1,9 @@
+.demo-prep {
+  h2 {
+    font-size: 2rem;
+  }
+
+  h3 {
+    font-size: 1.6rem;
+  }
+}

--- a/src/containers/consumerOnboarding/DemoPrep.test.tsx
+++ b/src/containers/consumerOnboarding/DemoPrep.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import DemoPrep from './DemoPrep';
+
+describe('DemoPrep', () => {
+  beforeEach(() => {
+    render(<DemoPrep />);
+  });
+
+  it('renders the main heading', () => {
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: 'Prepare for and complete a demo',
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it.each([
+    'We may also discuss API-specific needs or topics, depending on which API you’re using.',
+    'Post-demo tasks',
+  ])('renders the "%s" subheading as an h2', (headingText: string) => {
+    const heading = screen.getByRole('heading', {
+      level: 2,
+      name: headingText,
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it.each([
+    'Benefits Intake',
+    'Health',
+    'Veteran Verification',
+    'Appeals (internal VA only)',
+    'Loan Guaranty (internal VA only)',
+    'Address Validation (internal VA only)',
+  ])('renders the "%s" subheading as an h3', (api: string) => {
+    const heading = screen.getByRole('heading', {
+      level: 3,
+      name: api,
+    });
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/src/containers/consumerOnboarding/DemoPrep.test.tsx
+++ b/src/containers/consumerOnboarding/DemoPrep.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import DemoPrep from './DemoPrep';
 
 describe('DemoPrep', () => {
   beforeEach(() => {
-    render(<DemoPrep />);
+    render(
+      <Router>
+        <DemoPrep />
+      </Router>
+    );
   });
 
   it('renders the main heading', () => {

--- a/src/containers/consumerOnboarding/DemoPrep.tsx
+++ b/src/containers/consumerOnboarding/DemoPrep.tsx
@@ -1,0 +1,82 @@
+import classNames from 'classnames';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { PageHeader } from '../../components';
+import { CONSUMER_APIS_PATH } from '../../types/constants/paths';
+import './DemoPrep.scss';
+
+const DemoPrep: React.FunctionComponent = () => (
+  <div className="demo-prep">
+    <PageHeader header="Prepare for and complete a demo" />
+    <p>
+      Once any required changes are made, we aim to schedule the demo within a week. Demos
+      generally last from 30 to 60 minutes. Open data APIs do not require a demo.
+    </p>
+    <p>
+      Completing a successful demo, and making any necessary changes identified during the demo,
+      is the final step in your path toward production access.
+    </p>
+    <p>
+      During the demo, the following topics will be demonstrated or discussed:
+    </p>
+    <ul>
+      <li>User flows (your most common use case)</li>
+      <li>Data flows or diagrams</li>
+      <li>Any open issues and unanswered questions</li>
+    </ul>
+    <p>
+      We’ll provide usability feedback during the demo and also identify any follow-up actions or
+      changes, which we’ll communicate to you through email.
+    </p>
+    <h2 id="api-specific-requirements">
+      We may also discuss API-specific needs or topics, depending on which API you’re using.
+    </h2>
+    <h3>Benefits Intake</h3>
+    <ul>
+      <li>
+        Performing an upload with multiple attachments that progresses to the received status in
+        sandbox.
+      </li>
+      <li>
+        Using the <code>/download</code> endpoint to confirm that what is on the server matches the
+        payload you uploaded in its entirety.
+      </li>
+    </ul>
+    <h3>Health</h3>
+    <ul>
+      <li>Do you store health records at all, or only transmit them in session via the API?</li>
+      <li>How do you securely transmit and/or store PII/PHI?</li>
+      <li>
+        Must show this disclaimer: &quot;Service is for educational and informational purposes, not
+        clinical decisions.&quot;
+      </li>
+    </ul>
+    <h3>Veteran Verification</h3>
+    <p>No special topics.</p>
+    <h3>Appeals (internal VA only)</h3>
+    <p>No special topics.</p>
+    <h3>Loan Guaranty (internal VA only)</h3>
+    <p>No special topics.</p>
+    <h3>Address Validation (internal VA only)</h3>
+    <ul>
+      <li>Confirm internal VA or AWS GovCloud application</li>
+    </ul>
+    <h2
+      id="post-demo-tasks"
+      className={classNames(
+        'vads-u-border-bottom--5px',
+        'vads-u-border-color--primary',
+        'vads-u-padding-bottom--1',
+      )}
+    >
+      Post-demo tasks
+    </h2>
+    <p>
+      Future technical reviews and usability tests may be conducted if there are updates to your
+      application or the API. These reviews are conducted as part of the production API access renewal
+      process. Learn more about <Link to={CONSUMER_APIS_PATH}>working with our APIs</Link>.
+    </p>
+  </div>
+);
+
+export default DemoPrep;

--- a/src/containers/consumerOnboarding/OnboardingOverview.test.tsx
+++ b/src/containers/consumerOnboarding/OnboardingOverview.test.tsx
@@ -1,5 +1,6 @@
 import { getAllByRole, getByRole, render, screen } from '@testing-library/react';
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import {
   CONSUMER_APIS_PATH,
   CONSUMER_DEMO_PATH,
@@ -10,7 +11,11 @@ import OnboardingOverview from './OnboardingOverview';
 
 describe('OnboardingOverview', () => {
   beforeEach(() => {
-    render(<OnboardingOverview />);
+    render(
+      <Router>
+        <OnboardingOverview />
+      </Router>
+    );
   });
 
   it('renders the main heading', () => {

--- a/src/containers/consumerOnboarding/OnboardingOverview.tsx
+++ b/src/containers/consumerOnboarding/OnboardingOverview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { PageHeader } from '../../components';
 import {
   CONSUMER_APIS_PATH,
@@ -22,7 +23,7 @@ const ConsumerOnboardingOverview = (): JSX.Element => (
         <strong id="start-developing">Start developing</strong>
         <p>
           Access to our sandbox environment is automatic when you&nbsp;
-          <a href={CONSUMER_SANDBOX_PATH}>request an API key</a>.
+          <Link to={CONSUMER_SANDBOX_PATH}>request an API key</Link>.
         </p>
       </li>
       <li className="process-step list-two" aria-labelledby="request-prod-access">
@@ -31,21 +32,21 @@ const ConsumerOnboardingOverview = (): JSX.Element => (
           Getting production access can take less than a week to more than a month, depending on the API.
         </p>
         <p>
-          <a href={CONSUMER_PROD_PATH}>Learn what’s needed on the production access form.</a>
+          <Link to={CONSUMER_PROD_PATH}>Learn what’s needed on the production access form.</Link>
         </p>
       </li>
       <li className="process-step list-three" aria-labelledby="demo">
         <strong id="demo">Prepare for and complete a demo</strong>
         <p>
           We’ll review your production access request. Any changes we require must be made before&nbsp;
-          <a href={CONSUMER_DEMO_PATH}>your demo</a>. Open data APIs don’t require a demo.
+          <Link to={CONSUMER_DEMO_PATH}>your demo</Link>. Open data APIs don’t require a demo.
         </p>
       </li>
       <li className="process-step list-four" aria-labelledby="receive-prod-access">
         <strong id="receive-prod-access">Receive production access</strong>
         <p>
           After a successful demo, you’ll get production access. Learn more about&nbsp;
-          <a href={CONSUMER_APIS_PATH}>working with our APIs</a>.
+          <Link to={CONSUMER_APIS_PATH}>working with our APIs</Link>.
         </p>
       </li>
     </ol>
@@ -96,7 +97,7 @@ const ConsumerOnboardingOverview = (): JSX.Element => (
     </p>
     <p>
       The consumer onboarding pages describe how to get started using our APIs so you know what to expect
-      each step of the way–from <a href={CONSUMER_SANDBOX_PATH}>requesting automatic sandbox access</a>
+      each step of the way–from <Link to={CONSUMER_SANDBOX_PATH}>requesting automatic sandbox access</Link>
       &nbsp;to getting approved for production, and from troubleshooting to regular maintenance and beyond.
     </p>
   </div>

--- a/src/e2eHelpers.ts
+++ b/src/e2eHelpers.ts
@@ -2,6 +2,7 @@ import * as axe from 'axe-core';
 import { toHaveNoViolations } from 'jest-axe';
 import { Request } from 'puppeteer';
 import {
+  CONSUMER_DEMO_PATH,
   CONSUMER_PATH,
   PUBLISHING_ONBOARDING_PATH,
   PUBLISHING_PATH,
@@ -31,6 +32,7 @@ export const testPaths = [
   PUBLISHING_PATH,
   PUBLISHING_ONBOARDING_PATH,
   CONSUMER_PATH,
+  CONSUMER_DEMO_PATH,
 ];
 
 export const metadataTestPaths = [''];

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-prepare-for-and-complete-a-demo-properly-1-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-prepare-for-and-complete-a-demo-properly-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f36d072a776913c830941b03221b5835d23859e958505bc7df139355b2d044ad
+size 121422

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-prepare-for-and-complete-a-demo-properly-2-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-prepare-for-and-complete-a-demo-properly-2-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bec22c491ebcc355b8f5a85f141d3391487bf843de043612b96711036f32adf3
+size 135495

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-prepare-for-and-complete-a-demo-properly-3-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-prepare-for-and-complete-a-demo-properly-3-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6589df83a6a1e88b20b633cee28ac836be6c6c80c9257406879c371ef5a1cfd6
+size 131538


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

adds "prepare for a demo" page to consumer docs. completes [API-7690](https://vajira.max.gov/browse/API-7690).

- [design](https://www.figma.com/file/9sOD2GDAsyNTayvOqKlcJV/API-3854-Consumer?node-id=1397%3A840)
- [content](https://docs.google.com/document/d/1Q-uzP4nEz56tyFnprteMwzgaKi9BhqZHg_iqlkAn-Nw/edit)

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [X] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [n/a] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [X] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [X] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
