### PR TITLE
Add server error message

### DIFF
--- a/src/containers/support/ContactUsForm/ContactUsForm.test.tsx
+++ b/src/containers/support/ContactUsForm/ContactUsForm.test.tsx
@@ -268,4 +268,28 @@ describe('SupportContactUsFormPublishing', () => {
       });
     });
   });
+
+  it('displays a message when the server returns an error', async () => {
+    mockMakeRequest.mockRejectedValue({ message: 'there was an error' });
+
+    renderComponent();
+
+    await act(async () => {
+      await userEvent.type(screen.getByRole('textbox', { name: /First name/ }), 'Frodo', { delay: 0.01 });
+      await userEvent.type(screen.getByRole('textbox', { name: /Last name/ }), 'Baggins', { delay: 0.01 });
+      await userEvent.type(screen.getByRole('textbox', { name: /Email/ }), 'fbag@bagend.com', { delay: 0.01 });
+      await userEvent.type(screen.getByRole('textbox', {
+        name: /Describe your question or issue in as much detail as you can./,
+      }), 'The dark riders are coming', { delay: 0.01 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('We encountered a server error while saving your form. Please try again later.')).toBeInTheDocument();
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
 });

--- a/src/containers/support/ContactUsForm/ContactUsForm.tsx
+++ b/src/containers/support/ContactUsForm/ContactUsForm.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { Formik, Form } from 'formik';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import { CheckboxRadioField } from '../../../components';
 import { CONTACT_US_URL } from '../../../types/constants';
 import { makeRequest, ResponseType } from '../../../utils/makeRequest';
@@ -53,6 +54,7 @@ const processedData = (values: ContactUsFormState): SubmissionData => {
 };
 
 const ContactUsFormPublishing = ({ onSuccess, defaultType }: ContactUsFormProps): JSX.Element => {
+  const [submissionError, setSubmissionError] = useState(false);
   const initialValues: ContactUsFormState = {
     apiDescription: '',
     apiDetails: '',
@@ -68,15 +70,20 @@ const ContactUsFormPublishing = ({ onSuccess, defaultType }: ContactUsFormProps)
   };
 
   const formSubmission = async (values: ContactUsFormState): Promise<void> => {
-    await makeRequest(CONTACT_US_URL, {
-      body: JSON.stringify(processedData(values)),
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json',
-      },
-      method: 'POST',
-    }, { responseType: ResponseType.TEXT });
-    onSuccess();
+    setSubmissionError(false);
+    try {
+      await makeRequest(CONTACT_US_URL, {
+        body: JSON.stringify(processedData(values)),
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }, { responseType: ResponseType.TEXT });
+      onSuccess();
+    } catch {
+      setSubmissionError(true);
+    }
   };
 
   return (
@@ -105,9 +112,16 @@ const ContactUsFormPublishing = ({ onSuccess, defaultType }: ContactUsFormProps)
           }
 
           <button type="submit" className="vads-u-width--auto" disabled={!dirty || !isValid}>{isSubmitting ? 'Sending...' : 'Submit'}</button>
+          {submissionError && (
+            <AlertBox
+              status="error"
+              headline="We encountered a server error while saving your form. Please try again later."
+            />
+          )}
         </Form>
       )}
     </Formik>
+
   );
 };
 


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

This adds an alert box to the contact form if there is an error encountered while communicating with the server. This is setup to match what the apply page does currently.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [x] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
