### PR TITLE
[API-8109] - Disable the display of Claims Attributes API documentation

### DIFF
--- a/src/apiDefs/data/benefits.ts
+++ b/src/apiDefs/data/benefits.ts
@@ -67,7 +67,7 @@ const benefitsApis: APIDescription[] = [
         openApiUrl: `${OPEN_API_SPEC_HOST}/internal/docs/claims-attributes/v1/openapi.json`,
       },
     ],
-    enabledByDefault: true,
+    enabledByDefault: false,
     name: 'Claims Attributes',
     releaseNotes: ClaimsAttributesReleaseNotes,
     trustedPartnerOnly: false,


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->
Disables the display of `Claims Attributes` API documentation in preparation for the APIs upcoming deprecation.