### PR TITLE
Add team marmoset to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Okapi and Quokka manage the structural code for developer-portal.
-* @department-of-veterans-affairs/lighthouse-okapi @department-of-veterans-affairs/lighthouse-quokka @department-of-veterans-affairs/lighthouse-koala
+* @department-of-veterans-affairs/lighthouse-okapi @department-of-veterans-affairs/lighthouse-quokka @department-of-veterans-affairs/lighthouse-koala @department-of-veterans-affairs/lighthouse-marmoset
 
 


### PR DESCRIPTION
### Description

Add team marmoset to the codeowners for any jira tickets they'll need to do

