### PR TITLE
Remove implicit submitForm call from apply form

### DIFF
--- a/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.test.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.test.tsx
@@ -222,8 +222,8 @@ describe('SandboxAccessForm', () => {
       userEvent.click(submitButton);
 
       await waitFor(() => {
-        expect(mockMakeRequest).toHaveBeenCalled();
-        expect(mockOnSuccess).toHaveBeenCalled();
+        expect(mockMakeRequest).toHaveBeenCalledTimes(1);
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
@@ -10,7 +10,11 @@ import { useFlag } from '../../../../flags';
 import { makeRequest, ResponseType } from '../../../../utils/makeRequest';
 import { TextField, CheckboxRadioField } from '../../../../components';
 import { APPLY_URL, FLAG_CONSUMER_DOCS } from '../../../../types/constants';
-import { ApplySuccessResult, DevApplicationRequest, DevApplicationResponse } from '../../../../types';
+import {
+  ApplySuccessResult,
+  DevApplicationRequest,
+  DevApplicationResponse,
+} from '../../../../types';
 import { DeveloperInfo } from './DeveloperInfo';
 import SelectedApis from './SelectedApis';
 import { validateForm } from './validateForm';
@@ -88,7 +92,7 @@ const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
 
   return (
     <div className="vads-l-row">
-      {!consumerDocsEnabled &&
+      {!consumerDocsEnabled && (
         <p
           className={classNames(
             'usa-font-lead',
@@ -98,16 +102,14 @@ const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
           )}
         >
           This page is the first step towards developing with VA Lighthouse APIs. The keys and/or
-          credentials you will receive are for sandbox development only. When your app is ready to go
-          live, you may <Link to="/go-live">request production access</Link>. Please submit the form
-          below and you&apos;ll receive an email with your API key(s) and/or OAuth credentials, as
-          well as further instructions. Thank you for being a part of our platform.
-        </p>}
+          credentials you will receive are for sandbox development only. When your app is ready to
+          go live, you may <Link to="/go-live">request production access</Link>. Please submit the
+          form below and you&apos;ll receive an email with your API key(s) and/or OAuth credentials,
+          as well as further instructions. Thank you for being a part of our platform.
+        </p>
+      )}
       <div
-        className={classNames(
-          'vads-l-col--12',
-          { 'vads-u-padding-x--2p5': !consumerDocsEnabled },
-        )}
+        className={classNames('vads-l-col--12', { 'vads-u-padding-x--2p5': !consumerDocsEnabled })}
       >
         <Formik
           initialValues={initialValues}
@@ -116,9 +118,8 @@ const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
           validateOnBlur={false}
           validateOnChange={false}
         >
-          {({ isSubmitting, values, submitForm }): React.ReactNode => {
-            const handleSubmitButtonClick = async (): Promise<void> => {
-              await submitForm();
+          {({ isSubmitting, values }): React.ReactNode => {
+            const handleSubmitButtonClick = (): void => {
               setTimeout(() => {
                 const errorElements = document.querySelectorAll<HTMLElement>('[aria-invalid=true]');
 


### PR DESCRIPTION
### Description

This PR is for [API-8734](https://vajira.max.gov/browse/API-8734). Currently the `handleSubmit` function that creates an application in Okta, etc. is getting called twice. Removing the implicit `submitForm()` call makes it so the function is only called once.
### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

Do I have prettier misconfigured? I noticed that I have a lot of formatting changes in the `SandboxAccessForm.tsx` file
