### PR TITLE
Clarify the use of base64 to encode client_id and client_secret

### DIFF
--- a/src/components/oauthDocs/AuthCodeFlowContent.mdx
+++ b/src/components/oauthDocs/AuthCodeFlowContent.mdx
@@ -58,7 +58,7 @@ Location: <yourRedirectURL>?
 
 Use the following format, in HTTP basic authentication, for your request using the returned code and state parameters.
 
-- Use your client ID and client secret as the HTTP basic authentication username and password.
+- Use your client ID and client secret as the HTTP basic authentication username and password, encoded using base64.
 - Be sure to replace `<yourRedirectURL>` with the redirect URL that you provided during registration.
 
 <APISelector options={ props.options } selectedOption={ props.selectedOption } />
@@ -68,7 +68,7 @@ Use the following format, in HTTP basic authentication, for your request using t
 POST {{props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}}/token HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 grant_type=authorization_code
 &code=z92dapo5
@@ -132,7 +132,7 @@ Refresh tokens expire if they are not used for a period of 7 days in sandbox and
 POST {{props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}}/token HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 grant_type=refresh_token&refresh_token={ *refresh_token* }
 ```
@@ -166,7 +166,7 @@ Clients may revoke their own `access_tokens` and `refresh_tokens` using the revo
 POST {{props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}}/revoke HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 token={ *access_token* }&token_type_hint=access_token
 ```
@@ -180,7 +180,7 @@ token={ *access_token* }&token_type_hint=access_token
 POST {{props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}}/revoke HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 token={ *refresh_token* }&token_type_hint=refresh_token
 ```

--- a/src/components/oauthDocs/AuthCodeFlowContent.tsx
+++ b/src/components/oauthDocs/AuthCodeFlowContent.tsx
@@ -218,7 +218,7 @@ https://sandbox-api.va.gov${baseAuthPath}/authorization?
       <ul>
         <li>
           Use your client ID and client secret as the HTTP basic authentication username and
-          password.
+          password, encoded using base64.
         </li>
         <li>
           Be sure to replace <code>{'<yourRedirectURL>'}</code> with the redirect URL that you
@@ -232,7 +232,7 @@ https://sandbox-api.va.gov${baseAuthPath}/authorization?
 POST ${props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}/token HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 grant_type=authorization_code
 &code=z92dapo5&state=af0ifjsldkj
@@ -303,7 +303,7 @@ Pragma: no-cache
 POST ${props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}/token HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 grant_type=refresh_token&refresh_token={ *refresh_token* }`}
         </ReactMarkdown>
@@ -343,7 +343,7 @@ Host: sandbox-api.va.gov`}
 POST ${props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}/revoke HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 token={ *access_token* }&token_type_hint=access_token`}
         </ReactMarkdown>
@@ -355,7 +355,7 @@ token={ *access_token* }&token_type_hint=access_token`}
 POST ${props.apiDef?.oAuthInfo?.baseAuthPath ?? '/oauth2/{api}/v1'}/revoke HTTP/1.1
 Host: sandbox-api.va.gov
 Content-Type: application/x-www-form-urlencoded
-Authorization: Basic { base64 encoded *client_id* + ':' + *client_secret* }
+Authorization: Basic base64(client_id:client_secret)
 
 token={ *refresh_token* }&token_type_hint=refresh_token`}
         </ReactMarkdown>

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-properly-1-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-properly-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:659331a39ce704ec8f3eb1cbbfe836ecd8daac072271e358f2afe20ce4511579
-size 1495917
+oid sha256:c385c2a0ddc0b2a05c2a9f6632dd7de615296c4155e5c576c1ac8fe5e76710bc
+size 1498884

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-properly-3-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-properly-3-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8eeee43a7c3a23ca9f6a3054055f25d817bd31f9722170b87d2831970079019a
-size 1445441
+oid sha256:74789aecce7b1565ce296c6f83497fb4229883e31acf2efa29949d509afee41f
+size 1447682


### PR DESCRIPTION
### Description
Clarify the use of base64 to encode client_id and client_secret.

It should be clear that `client_id:client_secret` should be base64 encoded as a whole. Previous interpertation was that base64 only applied to `client_id`.
