### PR TITLE
fix: remove broken link to VA handbook

### DIFF
--- a/src/content/publishing/expectations/security.mdx
+++ b/src/content/publishing/expectations/security.mdx
@@ -22,7 +22,7 @@ We work hard to ensure your API is secure on Lighthouse by providing:
 ### Key policy highlights {#security-key-policy-highlights}
 
 - We rely on mature software such as: Kong (nginx), PostgreSQL, and Okta, which are used in other security-sensitive environments.
-- Our software runs in VA's [FISMA-compatible](https://www.cisa.gov/federal-information-security-modernization-act) Amazon Web Services (AWS) data center, which is subject to [VA Handbook](https://www.va.gov/vapubs/viewPublication.asp?Pub_ID=733&FType=2) 6500.3 continuous monitoring requirements.
+- Our software runs in VA's [FISMA-compatible](https://www.cisa.gov/federal-information-security-modernization-act) Amazon Web Services (AWS) data center, which is subject to VA Handbook continuous monitoring requirements.
 - We use a variety of methods to provide authentication and security.
 
 </div>
@@ -31,7 +31,7 @@ Lighthouse has a full authorization to operate (ATO) at the FISMA Moderate level
 
 Our [production](https://api.va.gov) and [sandbox](https://sandbox-api.va.gov) environments are deployed in the VA Enterprise Cloud's AWS GovCloud region, sitting behind the VA Trusted Internet Connection (TIC), and in compliance with VA’s external system network requirements.
 
-We rely on mature software that is used in other security-sensitive environments: Kong (nginx), PostgreSQL, and Okta. These are all running in VA's [FISMA-compatible](https://www.cisa.gov/federal-information-security-modernization-act) AWS data center and are subject to [VA Handbook](https://www.va.gov/vapubs/viewPublication.asp?Pub_ID=733&FType=2) 6500.3 continuous monitoring requirements.
+We rely on mature software that is used in other security-sensitive environments: Kong (nginx), PostgreSQL, and Okta. These are all running in VA's [FISMA-compatible](https://www.cisa.gov/federal-information-security-modernization-act) AWS data center and are subject to VA Handbook continuous monitoring requirements.
 
 ### Addressing Security Risks
 


### PR DESCRIPTION
### Description
This PR supports [API-9282](https://vajira.max.gov/browse/API-9282) by updating the expectations in the Security section to remove the broken link to the VA Handbook.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
