### PR TITLE
Update CI failure slackwebhook

### DIFF
--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -151,7 +151,7 @@ phases:
           ;;
         *)
           comment="An unhandled error occured with the build process. This is most likely a failure with the build pipeline. A post has been made in Slack"
-          slackpost.sh "CI Pipeline failure for the developer portal. CodeBuild URL: ${CODEBUILD_BUILD_URL}"
+          slackpost.sh "CI Pipeline failure for the developer portal. <${CODEBUILD_BUILD_URL}|CodeBuild URL>"
           ;;
         esac
       # Output build times

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -83,8 +83,6 @@ phases:
       # We will run these in a loop so we can handle the build failures correctly utilizing the phase variable.
       # Instead of checking for a combination of CODEBUILD_BUILD_SUCCEDING and some other variable we will assume
       # the phase variable is an indiation of the where the build failed and act accordingly in the POST_BUILD section.
-      # testing
-      - exit 1
       - phase=test
       - time="${time}\n${phase} - $(date +%r) - started"
       - |

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -41,7 +41,7 @@ env:
     DOCKER_USERNAME: '/dvp/devops/DOCKER_USERNAME'
     DOCKER_PASSWORD: '/dvp/devops/DOCKER_PASSWORD'
     # This webhook currently targets DSVA workspace #lighthous-deploys channel
-    SLACK_WEBHOOK: '/dvp/devops/codebuild_slack_webhook'
+    SLACK_WEBHOOK: '/dvp/devops/codebuild_slack_webhook_lighthouse'
 phases:
   install:
     commands:
@@ -149,7 +149,7 @@ phases:
           ;;
         *)
           comment="An unhandled error occured with the build process. This is most likely a failure with the build pipeline. A post has been made in Slack"
-          slackpost.sh "Pipeline failure for the developer portal"
+          slackpost.sh "CI Pipeline failure for the developer portal. CodeBuild Job: ${CODEBUILD_BUILD_ID}"
           ;;
         esac
       # Output build times

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -83,6 +83,8 @@ phases:
       # We will run these in a loop so we can handle the build failures correctly utilizing the phase variable.
       # Instead of checking for a combination of CODEBUILD_BUILD_SUCCEDING and some other variable we will assume
       # the phase variable is an indiation of the where the build failed and act accordingly in the POST_BUILD section.
+      # testing
+      - exit 1
       - phase=test
       - time="${time}\n${phase} - $(date +%r) - started"
       - |
@@ -149,7 +151,7 @@ phases:
           ;;
         *)
           comment="An unhandled error occured with the build process. This is most likely a failure with the build pipeline. A post has been made in Slack"
-          slackpost.sh "CI Pipeline failure for the developer portal. CodeBuild Job: ${CODEBUILD_BUILD_ID}"
+          slackpost.sh "CI Pipeline failure for the developer portal. CodeBuild URL: ${CODEBUILD_BUILD_ID}"
           ;;
         esac
       # Output build times

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -151,7 +151,7 @@ phases:
           ;;
         *)
           comment="An unhandled error occured with the build process. This is most likely a failure with the build pipeline. A post has been made in Slack"
-          slackpost.sh "CI Pipeline failure for the developer portal. CodeBuild URL: ${CODEBUILD_BUILD_ID}"
+          slackpost.sh "CI Pipeline failure for the developer portal. CodeBuild URL: ${CODEBUILD_BUILD_URL}"
           ;;
         esac
       # Output build times


### PR DESCRIPTION
### Description
When CI jobs fail outside of the test a notification is sent to Slack to see if there is a problem with CodeBuild. These notifications were using the wrong webhook and being sent to DSVA workspace. 
This PR also updates the message with codebuild ID for easier identification. 