### PR TITLE
Api 9709

### DIFF
--- a/src/containers/consumerOnboarding/ProductionAccess.tsx
+++ b/src/containers/consumerOnboarding/ProductionAccess.tsx
@@ -356,19 +356,19 @@ const ProductionAccess: FC = () => {
             validateOnChange={false}
           >
             <Form noValidate>
-              {activeStep === 0 ? (
+              {/* {activeStep === 0 ? (
                 <>
                   <SegmentedProgressBar current={1} total={4} ariaLabel={`Step 1: Verification`} />
                   <h2 className="vads-u-font-size--h4">Step 1: Verification</h2>
                 </>
-              ) : (
+              ) : ( */}
                 <>
-                  <SegmentedProgressBar current={activeStep + 1} total={steps.length} ariaLabel={`Step ${activeStep +1}: ${steps[activeStep]}`}/>
+                  <SegmentedProgressBar current={activeStep + 1} total={steps.length} ariaLabel={`Step ${activeStep + 1} of ${steps.length}: ${steps[activeStep]}`}/>
                   <h2 className="vads-u-font-size--h4">
                     {`Step ${activeStep + 1} of ${steps.length}: ${steps[activeStep]}`}
                   </h2>
                 </>
-              )}
+              {/* )} */}
               {renderStepContent(activeStep, passedStep1)}
               <div className="vads-u-margin-y--5">
                 <button

--- a/src/containers/consumerOnboarding/ProductionAccess.tsx
+++ b/src/containers/consumerOnboarding/ProductionAccess.tsx
@@ -358,12 +358,12 @@ const ProductionAccess: FC = () => {
             <Form noValidate>
               {activeStep === 0 ? (
                 <>
-                  <SegmentedProgressBar current={1} total={4} />
+                  <SegmentedProgressBar current={1} total={4} ariaLabel={`Step 1: Verification`} />
                   <h2 className="vads-u-font-size--h4">Step 1: Verification</h2>
                 </>
               ) : (
                 <>
-                  <SegmentedProgressBar current={activeStep + 1} total={steps.length} />
+                  <SegmentedProgressBar current={activeStep + 1} total={steps.length} ariaLabel={`Step ${activeStep +1}: ${steps[activeStep]}`}/>
                   <h2 className="vads-u-font-size--h4">
                     {`Step ${activeStep + 1} of ${steps.length}: ${steps[activeStep]}`}
                   </h2>


### PR DESCRIPTION
### Description

[API-9709](https://vajira.max.gov/browse/API-9709)
Makes a PR to the VADS component-library repo to allow SegmentedProgressBar to accept an optional ariaLabel prop that could override the default one and then make a descriptive ARIA label in the developer portal app with the updated version of component-library.

[Component Library PR](https://github.com/department-of-veterans-affairs/component-library/pull/176)

### Process

- [ ] Tests added or updated for change
- [ ] Docs updated
- [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
- [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [x] Accessibility concerns have been considered and addressed
- [x] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues
![8CE92BAD-FBAA-4B9D-8CE1-E5D6F05591F8_1_105_c](https://user-images.githubusercontent.com/25069483/135280943-84d679ea-27f6-46be-b16d-021a6b222f4d.jpeg)

### Requested feedback
