### PR TITLE
Removed consumer docs flags. Replaced /apply and /go-live urls with their new urls

### DIFF
--- a/src/App.e2e.ts
+++ b/src/App.e2e.ts
@@ -45,7 +45,7 @@ describe('App', () => {
      * access to this link whereever they are.
      */
     it('is displayed in the footer', async () => {
-      for (const path of ['/', '/apply', '/explore']) {
+      for (const path of ['/', '/explore']) {
         await page.goto(`${puppeteerHost}${path}`, { waitUntil: 'networkidle0' });
         const tosLinkCount = await page.evaluate(() => {
           const pathExpr = "//footer//a[contains(., 'Terms of Service')]";

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -5,17 +5,14 @@ import { Redirect, Route } from 'react-router-dom';
 import { getActiveApiDefinitions, getApiCategoryOrder } from './apiDefs/query';
 import { MarkdownPage } from './components';
 import ConsumerOnboardingRoot from './containers/consumerOnboarding/ConsumerOnboardingRoot';
-import DisabledApplyForm from './containers/DisabledApplyForm';
 import DocumentationRoot from './containers/documentation/DocumentationRoot';
 import Home from './containers/Home';
 import News from './containers/News';
 import ErrorPage from './containers/ErrorPage';
 import ReleaseNotes from './containers/releaseNotes/ReleaseNotes';
 import Support, { sections as supportSections, SupportSection } from './containers/support/Support';
-import PathToProduction from './content/goLive.mdx';
 import TermsOfService from './content/termsOfService.mdx';
 import ProviderIntegrationGuide from './content/providers/integrationGuide.mdx';
-import { Flag, getFlags } from './flags';
 import { Publishing } from './containers/publishing';
 import {
   CONSUMER_APPLICATION_PATH,
@@ -24,13 +21,10 @@ import {
   CONSUMER_SANDBOX_PATH,
   PUBLISHING_ROUTER_PATHS,
 } from './types/constants/paths';
-import { Apply } from './containers/apply/Apply';
-import { FLAG_SIGNUPS_ENABLED } from './types/constants';
 import { buildApiDetailRoutes } from './utils/routesHelper';
 import ProductionAccess from './containers/consumerOnboarding/ProductionAccess';
 
 export const SiteRoutes: React.FunctionComponent = (): JSX.Element => {
-  const flags = getFlags();
   const apiDefinitions = getActiveApiDefinitions();
   return (
     <Switch>
@@ -92,32 +86,16 @@ export const SiteRoutes: React.FunctionComponent = (): JSX.Element => {
       ))}
 
       {/* Consumer Docs */}
-      {flags.consumer_docs && (
-        <Route path={CONSUMER_APPLICATION_PATH} component={ProductionAccess} />
-      )}
-      {flags.consumer_docs &&
-        CONSUMER_ROUTER_PATHS.map((path: string) => (
-          <Route exact path={path} component={ConsumerOnboardingRoot} key={path} />
-        ))}
 
-      {flags.consumer_docs ? (
-        <Redirect from="/apply" to={CONSUMER_SANDBOX_PATH} />
-      ) : (
-        <Route
-          path="/apply"
-          render={(): JSX.Element => (
-            <Flag
-              name={[FLAG_SIGNUPS_ENABLED]}
-              component={Apply}
-              fallbackComponent={DisabledApplyForm}
-            />
-          )}
-        />
-      )}
+      <Route path={CONSUMER_APPLICATION_PATH} component={ProductionAccess} />
 
-      {flags.consumer_docs ? (
-        <Redirect from="/go-live" to={CONSUMER_PROD_PATH} />
-      ) : <Route path="/go-live" render={(): JSX.Element => MarkdownPage(PathToProduction)} />}
+      {CONSUMER_ROUTER_PATHS.map((path: string) => (
+        <Route exact path={path} component={ConsumerOnboardingRoot} key={path} />
+      ))}
+
+      <Redirect from="/apply" to={CONSUMER_SANDBOX_PATH} />
+
+      <Redirect from="/go-live" to={CONSUMER_PROD_PATH} />
 
       {/* Catch the rest with the 404 */}
       <Route render={(): JSX.Element => <ErrorPage errorCode={404} />} />

--- a/src/components/apiTags/ApiTags.tsx
+++ b/src/components/apiTags/ApiTags.tsx
@@ -1,7 +1,5 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { Flag } from '../../flags';
-import { FLAG_CONSUMER_DOCS } from '../../types/constants';
 import ApiTag, { tagTypes } from './ApiTag';
 
 const ApiTagsPropTypes = {
@@ -13,7 +11,7 @@ type ApiTagsProps = PropTypes.InferProps<typeof ApiTagsPropTypes>;
 const ApiTags: React.FunctionComponent<ApiTagsProps> = (props: ApiTagsProps): JSX.Element => (
   <>
     {props.vaInternalOnly && <ApiTag type={tagTypes.VAInternalOnly} />}
-    <Flag name={[FLAG_CONSUMER_DOCS]}>{props.openData && <ApiTag type={tagTypes.OpenData} />}</Flag>
+    {props.openData && <ApiTag type={tagTypes.OpenData} />}
   </>
 );
 

--- a/src/components/header/Header.test.tsx
+++ b/src/components/header/Header.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { FlagsProvider, getFlags } from '../../flags';
+import { CONSUMER_SANDBOX_PATH } from '../../types/constants/paths';
 import { Header } from './Header';
 
 describe('Header', () => {
@@ -38,7 +39,7 @@ describe('Header', () => {
     }) as HTMLAnchorElement[];
 
     expect(requestAPIKeyLinks.length).toBe(2);
-    expect(requestAPIKeyLinks[0].getAttribute('href')).toBe('/apply');
+    expect(requestAPIKeyLinks[0].getAttribute('href')).toBe(CONSUMER_SANDBOX_PATH);
   });
 
   describe('when the menu button is clicked', () => {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -7,6 +7,7 @@ import { Banner, NavBar } from '../../components';
 import { Flag } from '../../flags';
 import { defaultFlexContainer, desktopOnly, mobileOnly } from '../../styles/vadsUtils';
 import { FLAG_PLATFORM_OUTAGE, FLAG_SHOW_TESTING_NOTICE } from '../../types/constants';
+import { CONSUMER_SANDBOX_PATH } from '../../types/constants/paths';
 import VeteransCrisisLine from '../crisisLine/VeteransCrisisLine';
 import Search from '../search/Search';
 import TestingNotice from '../TestingNotice';
@@ -82,7 +83,7 @@ const Header = (): JSX.Element => {
           <div className={desktopOnly()}>
             <div className={classNames('vads-u-display--flex', 'vads-u-flex-direction--column')}>
               <div className={defaultFlexContainer(true)}>
-                <NavHashLink to="/apply" className={buttonClassnames}>
+                <NavHashLink to={CONSUMER_SANDBOX_PATH} className={buttonClassnames}>
                   Request an API Key
                 </NavHashLink>
                 <Search />
@@ -113,11 +114,14 @@ const Header = (): JSX.Element => {
             content={
               <section aria-label="Network issue alert">
                 {/* message written for specific issue on 8/25/21, update next time it needs to be used */}
-                There were recent network issues affecting all VA sites and usage of VA Lighthouse APIs in
-                sandbox and production environments from 9:56 am to 10:44 am EDT. Please review the&nbsp;
-                <a href="https://valighthouse.statuspage.io/" target="_blank" rel="noreferrer">Status Page</a>
-                &nbsp;for details and reach out to <Link to="/support/contact-us">Support</Link> if you
-                have any questions.
+                There were recent network issues affecting all VA sites and usage of VA Lighthouse
+                APIs in sandbox and production environments from 9:56 am to 10:44 am EDT. Please
+                review the&nbsp;
+                <a href="https://valighthouse.statuspage.io/" target="_blank" rel="noreferrer">
+                  Status Page
+                </a>
+                &nbsp;for details and reach out to <Link to="/support/contact-us">Support</Link> if
+                you have any questions.
               </section>
             }
             className="vads-u-margin-top--0"

--- a/src/components/hero/Hero.test.tsx
+++ b/src/components/hero/Hero.test.tsx
@@ -3,6 +3,7 @@ import 'jest';
 import { render, screen } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import * as logoImage from '../../__mocks__/fakeImage';
+import { CONSUMER_SANDBOX_PATH } from '../../types/constants/paths';
 import { Hero } from './Hero';
 
 describe('Hero', () => {
@@ -23,7 +24,7 @@ describe('Hero', () => {
   it('contains a link to apply page', () => {
     const apiLink = screen.getByRole('link', { name: 'Request an API Key' });
     expect(apiLink).toBeInTheDocument();
-    expect(apiLink).toHaveAttribute('href', '/apply');
+    expect(apiLink).toHaveAttribute('href', CONSUMER_SANDBOX_PATH);
   });
 
   it('checks h1 text', () => {

--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import logo from '../../assets/hero-logo.svg';
+import { CONSUMER_SANDBOX_PATH } from '../../types/constants/paths';
 
 const Hero: React.FunctionComponent = (): JSX.Element => (
   <section
@@ -34,7 +35,7 @@ const Hero: React.FunctionComponent = (): JSX.Element => (
         </h1>
         <Link
           id="hero-read-api-docs"
-          to="/apply"
+          to={CONSUMER_SANDBOX_PATH}
           className={classNames(
             'usa-button',
             'va-api-button-default',

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import { match as Match } from 'react-router';
 import { NavHashLink } from 'react-router-hash-link';
-import { FLAG_CATEGORIES, FLAG_CONSUMER_DOCS } from '../../types/constants';
+import { FLAG_CATEGORIES } from '../../types/constants';
 import {
   CONSUMER_APIS_PATH,
   CONSUMER_DEMO_PATH,
@@ -169,35 +169,51 @@ const NavBar = (props: NavBarProps): JSX.Element => {
               ))}
             </SubNav>
           </li>
-          <Flag name={[FLAG_CONSUMER_DOCS]}>
-            <li className={navItemStyles()}>
-              <MainNavItem
-                targetUrl={CONSUMER_PATH}
-                largeScreenProps={sharedNavItemProps}
-                excludeSmallScreen
-                className={navLinkStyles}
+
+          <li className={navItemStyles()}>
+            <MainNavItem
+              targetUrl={CONSUMER_PATH}
+              largeScreenProps={sharedNavItemProps}
+              excludeSmallScreen
+              className={navLinkStyles}
+            >
+              Onboarding
+            </MainNavItem>
+            <SubNav name="Onboarding">
+              <SubNavEntry
+                onClick={props.onMobileNavClose}
+                to={CONSUMER_PATH}
+                id="onboarding-overview"
               >
-                Onboarding
-              </MainNavItem>
-              <SubNav name="Onboarding">
-                <SubNavEntry onClick={props.onMobileNavClose} to={CONSUMER_PATH} id="onboarding-overview">
-                  Overview
-                </SubNavEntry>
-                <SubNavEntry onClick={props.onMobileNavClose} to={CONSUMER_SANDBOX_PATH} id="sandbox-access">
-                  Request sandbox access
-                </SubNavEntry>
-                <SubNavEntry onClick={props.onMobileNavClose} to={CONSUMER_PROD_PATH} id="prod-access">
-                  Request production access
-                </SubNavEntry>
-                <SubNavEntry onClick={props.onMobileNavClose} to={CONSUMER_DEMO_PATH} id="demo">
-                  Prepare for the demo
-                </SubNavEntry>
-                <SubNavEntry onClick={props.onMobileNavClose} to={CONSUMER_APIS_PATH} id="working-with-apis">
-                  Working with our APIs
-                </SubNavEntry>
-              </SubNav>
-            </li>
-          </Flag>
+                Overview
+              </SubNavEntry>
+              <SubNavEntry
+                onClick={props.onMobileNavClose}
+                to={CONSUMER_SANDBOX_PATH}
+                id="sandbox-access"
+              >
+                Request sandbox access
+              </SubNavEntry>
+              <SubNavEntry
+                onClick={props.onMobileNavClose}
+                to={CONSUMER_PROD_PATH}
+                id="prod-access"
+              >
+                Request production access
+              </SubNavEntry>
+              <SubNavEntry onClick={props.onMobileNavClose} to={CONSUMER_DEMO_PATH} id="demo">
+                Prepare for the demo
+              </SubNavEntry>
+              <SubNavEntry
+                onClick={props.onMobileNavClose}
+                to={CONSUMER_APIS_PATH}
+                id="working-with-apis"
+              >
+                Working with our APIs
+              </SubNavEntry>
+            </SubNav>
+          </li>
+
           <li className={navItemStyles()}>
             <MainNavItem
               onClick={props.onMobileNavClose}
@@ -287,7 +303,7 @@ const NavBar = (props: NavBarProps): JSX.Element => {
           <div className={classNames('va-api-nav-secondary', 'vads-u-margin-y--2')}>
             <NavHashLink
               onClick={props.onMobileNavClose}
-              to="/apply"
+              to={CONSUMER_SANDBOX_PATH}
               className={classNames('usa-button', 'vads-u-width--full')}
             >
               Request an API Key

--- a/src/components/oauthDocs/GettingStarted.tsx
+++ b/src/components/oauthDocs/GettingStarted.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
+import { CONSUMER_SANDBOX_PATH } from '../../types/constants/paths';
 import { SectionHeaderWrapper } from '../index';
 
 const GettingStarted = (): JSX.Element => (
@@ -14,9 +15,9 @@ const GettingStarted = (): JSX.Element => (
       third party being authorized depends on the API.
     </p>
     <p>
-      The first step toward authorization is to <Link to="/apply">fill out our application</Link>{' '}
-      and make sure to select the right OAuth API for your needs. To complete the form, you will
-      need:
+      The first step toward authorization is to{' '}
+      <Link to={CONSUMER_SANDBOX_PATH}>fill out our application</Link> and make sure to select the
+      right OAuth API for your needs. To complete the form, you will need:
     </p>
     <ul>
       <li>Your organization name</li>

--- a/src/components/oauthDocs/PageLinks.tsx
+++ b/src/components/oauthDocs/PageLinks.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import { AuthCodeFlowContentProps } from '../../containers/documentation/AuthorizationDocs';
+import { CONSUMER_PROD_PATH } from '../../types/constants/paths';
 import { APISelector } from '../apiSelector/APISelector';
 
 const PageLinks = (props: AuthCodeFlowContentProps): JSX.Element => (
@@ -98,7 +99,7 @@ const PageLinks = (props: AuthCodeFlowContentProps): JSX.Element => (
       </li>
       <li>
         When your application is ready, you may{' '}
-        <Link to="/go-live">apply for production access</Link>.
+        <Link to={CONSUMER_PROD_PATH}>apply for production access</Link>.
       </li>
     </ul>
   </>

--- a/src/components/pageContent/PageContent.test.tsx
+++ b/src/components/pageContent/PageContent.test.tsx
@@ -48,7 +48,7 @@ describe('PageContent', () => {
       name: 'Request Sandbox Access',
     });
 
-    expect(window.scrollTo).toHaveBeenCalledTimes(2);
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 });

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -9,7 +9,7 @@ import './Home.scss';
 import apiDefinitions, { apiCategoryOrder } from '../apiDefs/data/categories';
 import { CardLink, Hero } from '../components';
 import { Flag } from '../flags';
-import { FLAG_CATEGORIES, FLAG_CONSUMER_DOCS } from '../types/constants';
+import { FLAG_CATEGORIES } from '../types/constants';
 
 const columnContentClasses = classNames(
   'vads-u-text-align--center',
@@ -118,17 +118,15 @@ const Home = (): JSX.Element => (
             for Veterans. Explore usage policies and technical details about VA&apos;s API
             offerings.
           </ColumnContent>
-          <Flag name={[FLAG_CONSUMER_DOCS]}>
-            <ColumnContent
-              title="Consumer Onboarding"
-              imageSrc={rocketImage}
-              buttonDestination="/onboarding"
-              buttonText="Review the onboarding process"
-            >
-              We review the quality and security of all applications integrating with our APIs and
-              data before they go live.
-            </ColumnContent>
-          </Flag>
+          <ColumnContent
+            title="Consumer Onboarding"
+            imageSrc={rocketImage}
+            buttonDestination="/onboarding"
+            buttonText="Review the onboarding process"
+          >
+            We review the quality and security of all applications integrating with our APIs and
+            data before they go live.
+          </ColumnContent>
           <ColumnContent
             title="API Publishing"
             imageSrc={branchImage}

--- a/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
@@ -6,10 +6,9 @@ import { Link } from 'react-router-dom';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 import { Form, Formik } from 'formik';
-import { useFlag } from '../../../../flags';
 import { HttpErrorResponse, makeRequest, ResponseType } from '../../../../utils/makeRequest';
 import { TextField, TermsOfServiceCheckbox } from '../../../../components';
-import { APPLY_URL, FLAG_CONSUMER_DOCS } from '../../../../types/constants';
+import { APPLY_URL } from '../../../../types/constants';
 import {
   ApplySuccessResult,
   DevApplicationRequest,
@@ -17,6 +16,7 @@ import {
   InternalApiInfo,
 } from '../../../../types';
 import { includesInternalOnlyAPI } from '../../../../apiDefs/query';
+import { CONSUMER_PROD_PATH } from '../../../../types/constants/paths';
 import { DeveloperInfo } from './DeveloperInfo';
 import SelectedApis from './SelectedApis';
 import { validateForm } from './validateForm';
@@ -64,7 +64,6 @@ interface SandboxAccessFormError extends HttpErrorResponse {
 const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
   const [submissionHasError, setSubmissionHasError] = useState(false);
   const [submissionErrors, setSubmissionErrors] = useState<string[]>([]);
-  const consumerDocsEnabled = useFlag([FLAG_CONSUMER_DOCS]);
 
   const handleSubmit = async (values: Values): Promise<void> => {
     setSubmissionHasError(false);
@@ -119,23 +118,21 @@ const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
 
   return (
     <div className="vads-l-row">
-      {!consumerDocsEnabled && (
-        <p
-          className={classNames(
-            'usa-font-lead',
-            'vads-u-font-family--sans',
-            'vads-u-margin-bottom--2',
-            'vads-u-margin-top--0',
-          )}
-        >
-          This page is the first step towards developing with VA Lighthouse APIs. The keys and/or
-          credentials you will receive are for sandbox development only. When your app is ready to
-          go live, you may <Link to="/go-live">request production access</Link>. Please submit the
-          form below and you&apos;ll receive an email with your API key(s) and/or OAuth credentials,
-          as well as further instructions. Thank you for being a part of our platform.
-        </p>
-      )}
-      <div className={classNames({ 'vads-u-padding-x--2p5': !consumerDocsEnabled })}>
+      <p
+        className={classNames(
+          'usa-font-lead',
+          'vads-u-font-family--sans',
+          'vads-u-margin-bottom--2',
+          'vads-u-margin-top--0',
+        )}
+      >
+        This page is the first step towards developing with VA Lighthouse APIs. The keys and/or
+        credentials you will receive are for sandbox development only. When your app is ready to go
+        live, you may <Link to={CONSUMER_PROD_PATH}>request production access</Link>. Please submit
+        the form below and you&apos;ll receive an email with your API key(s) and/or OAuth
+        credentials, as well as further instructions. Thank you for being a part of our platform.
+      </p>
+      <div className="vads-u-padding-x--2p5">
         <Formik
           initialValues={initialValues}
           onSubmit={handleSubmit}

--- a/src/containers/documentation/CategoryPage.tsx
+++ b/src/containers/documentation/CategoryPage.tsx
@@ -10,7 +10,7 @@ import { APIDescription } from '../../apiDefs/schema';
 import { CardLink, ApiTags, PageHeader } from '../../components';
 import { defaultFlexContainer } from '../../styles/vadsUtils';
 import { APINameParam } from '../../types';
-import { FLAG_HOSTED_APIS, PAGE_HEADER_ID, FLAG_CONSUMER_DOCS } from '../../types/constants';
+import { FLAG_HOSTED_APIS, PAGE_HEADER_ID } from '../../types/constants';
 import { CONSUMER_PATH } from '../../types/constants/paths';
 
 const CategoryPage = (): JSX.Element => {
@@ -25,8 +25,7 @@ const CategoryPage = (): JSX.Element => {
   let cardSection;
   if (apis.length > 0) {
     const apiCards = apis.map((apiDesc: APIDescription) => {
-      const { description, name, urlFragment, vaInternalOnly, openData } =
-        apiDesc;
+      const { description, name, urlFragment, vaInternalOnly, openData } = apiDesc;
       return (
         <Flag key={name} name={[FLAG_HOSTED_APIS, urlFragment]}>
           <CardLink
@@ -66,11 +65,9 @@ const CategoryPage = (): JSX.Element => {
       )}
       <div className="vads-u-width--full">
         {overview({})}
-        <Flag name={[FLAG_CONSUMER_DOCS]}>
-          <p>
-            <Link to={CONSUMER_PATH}>{consumerDocsLinkText}</Link>.
-          </p>
-        </Flag>
+        <p>
+          <Link to={CONSUMER_PATH}>{consumerDocsLinkText}</Link>.
+        </p>
       </div>
       {cardSection}
     </div>

--- a/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
@@ -19,6 +19,7 @@ import SwaggerUI from 'swagger-ui';
 import * as React from 'react';
 import * as decisionReviews from '../../../__mocks__/openAPIData/decisionReviews.test.json';
 import * as fhirR4 from '../../../__mocks__/openAPIData/fhirR4.test.json';
+import { CONSUMER_SANDBOX_PATH } from '../../../types/constants/paths';
 import { SwaggerPlugins, System } from './index';
 
 /**
@@ -145,7 +146,7 @@ describe('CurlForm', () => {
 
         const applyLink = getByRole(applyMessage, 'link', { name: 'Get One' });
         expect(applyLink).toBeInTheDocument();
-        expect(applyLink.getAttribute('href')).toBe('/apply');
+        expect(applyLink.getAttribute('href')).toBe(CONSUMER_SANDBOX_PATH);
       };
 
       // key-auth API

--- a/src/containers/documentation/swaggerPlugins/CurlForm.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.tsx
@@ -17,6 +17,7 @@ import {
 } from 'swagger-ui';
 import { v4 as uuidv4 } from 'uuid';
 import { CodeWrapper } from '../../../components';
+import { CONSUMER_SANDBOX_PATH } from '../../../types/constants/paths';
 import { System } from './types';
 
 import './CurlForm.scss';
@@ -180,11 +181,13 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
            * OAuth 2.0 security (Health): https://swagger.io/docs/specification/authentication/oauth2/
            * https://github.com/swagger-api/swagger-js/blob/master/src/execute/oas3/build-request.js#L78
            */
-          OauthFlow: token ? {
-            token: {
-              access_token: token,
-            },
-          } : undefined,
+          OauthFlow: token
+            ? {
+                token: {
+                  access_token: token,
+                },
+              }
+            : undefined,
           bearer_token: token,
         },
       };
@@ -202,9 +205,10 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
         requestBody[property.name] = this.state.paramValues[property.name].split(',');
       } else if (property.type === 'object') {
         try {
-          requestBody[property.name] = JSON.parse(
-            this.state.paramValues[property.name],
-          ) as Record<string, unknown>;
+          requestBody[property.name] = JSON.parse(this.state.paramValues[property.name]) as Record<
+            string,
+            unknown
+          >;
         } catch (e: unknown) {
           requestBody[property.name] = this.state.paramValues[property.name];
         }
@@ -265,7 +269,7 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
               }}
             />
             <small>
-              Don&apos;t have an API Key? <a href="/apply"> Get One </a>
+              Don&apos;t have an API Key? <a href={CONSUMER_SANDBOX_PATH}> Get One </a>
             </small>
           </div>
         </div>
@@ -283,7 +287,7 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
               }}
             />
             <small>
-              Don&apos;t have an API Key? <a href="/apply"> Get One </a>
+              Don&apos;t have an API Key? <a href={CONSUMER_SANDBOX_PATH}> Get One </a>
             </small>
           </div>
         </div>

--- a/src/containers/publishing/components/publishingOnboarding/PublishingOnboarding.tsx
+++ b/src/containers/publishing/components/publishingOnboarding/PublishingOnboarding.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { PageHeader } from '../../../../components';
+import { CONSUMER_PROD_PATH } from '../../../../types/constants/paths';
 
 export const PublishingOnboarding: FC = () => (
   <>
@@ -10,31 +11,40 @@ export const PublishingOnboarding: FC = () => (
     </Helmet>
     <PageHeader header="How publishing works" />
     <p>
-      The process of publishing your API with Lighthouse can seem daunting, but don’t worry.
-      Our process is designed to ensure your questions are answered and we are both prepared for
-      your API’s go-live day and beyond. Here’s what you can expect during the publishing process.
+      The process of publishing your API with Lighthouse can seem daunting, but don’t worry. Our
+      process is designed to ensure your questions are answered and we are both prepared for your
+      API’s go-live day and beyond. Here’s what you can expect during the publishing process.
       Remember, we’re here for you each step of the way.
     </p>
     <ol className="process">
       <li className="process-step list-one">
         <strong>Contact us</strong>
         <p>
-          Get the process started by filling out the Contact Us form. You’ll need to gather information
-          about you and your API and send it to us so we know how we can best support you.
+          Get the process started by filling out the Contact Us form. You’ll need to gather
+          information about you and your API and send it to us so we know how we can best support
+          you.
         </p>
       </li>
       <li className="process-step list-two">
         <strong>Kickoff meeting</strong>
-        <p>We’ll answer many of your questions about API publishing with Lighthouse  as part of the kickoff meeting.</p>
+        <p>
+          We’ll answer many of your questions about API publishing with Lighthouse as part of the
+          kickoff meeting.
+        </p>
       </li>
       <li className="process-step list-three">
         <strong>Prepare your API for publication</strong>
-        <p>After kickoff, we will both complete tasks that will get your API ready for publication to our sandbox</p>
+        <p>
+          After kickoff, we will both complete tasks that will get your API ready for publication to
+          our sandbox
+        </p>
         environment and then production.
       </li>
       <li className="process-step list-four">
         <strong>Onboard consumers</strong>
-        <p>Once the hard work is done and your API is published, it’s time to onboard your consumers.</p>
+        <p>
+          Once the hard work is done and your API is published, it’s time to onboard your consumers.
+        </p>
       </li>
     </ol>
     <h2>Contact us</h2>
@@ -48,12 +58,14 @@ export const PublishingOnboarding: FC = () => (
       <li>OpenAPI specification and public-facing description, if you have it</li>
       <li>Information on public or internal VA network accessibility</li>
     </ul>
-    <Link to="/support/contact-us" className="usa-button usa-button-secondary">Contact Us</Link>
+    <Link to="/support/contact-us" className="usa-button usa-button-secondary">
+      Contact Us
+    </Link>
     <h2>Kickoff meeting</h2>
     <p>
-      At the kickoff meeting, we’ll introduce our teams, ask questions, clarify expectations, and discuss
-      timelines. A successful kickoff meeting ensures we all know what’s needed going forward. Here are some
-      examples of what you can expect to discuss during the kickoff meeting.
+      At the kickoff meeting, we’ll introduce our teams, ask questions, clarify expectations, and
+      discuss timelines. A successful kickoff meeting ensures we all know what’s needed going
+      forward. Here are some examples of what you can expect to discuss during the kickoff meeting.
     </p>
     <table>
       <thead>
@@ -82,7 +94,7 @@ export const PublishingOnboarding: FC = () => (
           <td>
             <ul>
               <li>Technical considerations</li>
-              <li>High-interest topics such as rate limiting, publishing  timeline, and more</li>
+              <li>High-interest topics such as rate limiting, publishing timeline, and more</li>
               <li>Coordination and communications</li>
             </ul>
           </td>
@@ -95,9 +107,9 @@ export const PublishingOnboarding: FC = () => (
     </p>
     <h2>Prepare your API for publication</h2>
     <p>
-      We’re here to make sure nothing gets overlooked as we publish your API in the sandbox environment
-      and then production. After kickoff, we’ll be with you every step of the way as we both complete tasks
-      to expose your API on Lighthouse. Here’s some of what you can expect.
+      We’re here to make sure nothing gets overlooked as we publish your API in the sandbox
+      environment and then production. After kickoff, we’ll be with you every step of the way as we
+      both complete tasks to expose your API on Lighthouse. Here’s some of what you can expect.
     </p>
     <table>
       <thead>
@@ -125,7 +137,10 @@ export const PublishingOnboarding: FC = () => (
               <li>Get you access to our document repository</li>
               <li>Schedule any needed publishing and maintenance check-ins</li>
               <li>Provide feedback on API documentation and spec</li>
-              <li>Propose route(s) for the API on <Link to="https://api.va.gov">https://api.va.gov</Link></li>
+              <li>
+                Propose route(s) for the API on{' '}
+                <Link to="https://api.va.gov">https://api.va.gov</Link>
+              </li>
               <li>Propose where the API will live in our information architecture</li>
             </ul>
           </td>
@@ -143,10 +158,11 @@ export const PublishingOnboarding: FC = () => (
     </table>
     <h2>Onboard consumers</h2>
     <p>
-      Onboarding existing and new consumers is easy when you have our support. As part of preparing your API
-      for publication, we’ll have a consumer migration plan ready to go. When you reach this phase of your API
-      publishing journey, it’s as simple as identifying your first consumer to onboard and following the plan
-      we’ve created together. Consumers must get production access by following our <Link to="/go-live">path to production guide</Link>.
+      Onboarding existing and new consumers is easy when you have our support. As part of preparing
+      your API for publication, we’ll have a consumer migration plan ready to go. When you reach
+      this phase of your API publishing journey, it’s as simple as identifying your first consumer
+      to onboard and following the plan we’ve created together. Consumers must get production access
+      by following our <Link to={CONSUMER_PROD_PATH}>path to production guide</Link>.
     </p>
   </>
 );

--- a/src/containers/support/FAQ.tsx
+++ b/src/containers/support/FAQ.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { AccordionPanelContent, GroupedAccordions, PageHeader } from '../../components';
+import { CONSUMER_PROD_PATH, CONSUMER_SANDBOX_PATH } from '../../types/constants/paths';
 
 const generalQuestions: SupportQuestion[] = [
   {
@@ -43,10 +44,11 @@ const developmentQuestions: SupportQuestion[] = [
   {
     answer: (
       <p>
-        Click to <Link to="/apply">Get Started</Link> by applying for an API key. Note that you will
-        need to provide your <Link to="/oauth">OAuth</Link> Redirect URI if you are applying for a
-        key to the Health, Claims, or Veteran Verification APIs. You are also required to agree to
-        the <Link to="/terms-of-service">VA API Terms of Service</Link> in order to obtain a key.
+        Click to <Link to={CONSUMER_SANDBOX_PATH}>Get Started</Link> by applying for an API key.
+        Note that you will need to provide your <Link to="/oauth">OAuth</Link> Redirect URI if you
+        are applying for a key to the Health, Claims, or Veteran Verification APIs. You are also
+        required to agree to the <Link to="/terms-of-service">VA API Terms of Service</Link> in
+        order to obtain a key.
       </p>
     ),
     question: 'Where do I apply for dev access?',
@@ -54,9 +56,9 @@ const developmentQuestions: SupportQuestion[] = [
   {
     answer: (
       <p>
-        Visit the <Link to="/go-live">Path to Production</Link> page for instructions on &quot;going
-        live.&quot; Schedule a demo presentation of your app by using the Contact Us, or by
-        submitting a request via the GitHub links.
+        Visit the <Link to={CONSUMER_PROD_PATH}>Path to Production</Link> page for instructions on
+        &quot;going live.&quot; Schedule a demo presentation of your app by using the Contact Us, or
+        by submitting a request via the GitHub links.
       </p>
     ),
     question: 'How do we move forward with production API access once dev is complete?',

--- a/src/e2eHelpers.ts
+++ b/src/e2eHelpers.ts
@@ -17,9 +17,7 @@ import { mockSwagger as mocks } from './__mocks__/mockSwagger';
 // Paths to test in visual regression and accessibility tests
 export const testPaths = [
   '/',
-  '/apply',
   '/terms-of-service',
-  '/go-live',
   '/explore',
   '/explore/authorization',
   '/explore/health',

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -5,7 +5,6 @@ import { getAllApis } from './apiDefs/query';
 import { APIDescription } from './apiDefs/schema';
 import {
   FLAG_CATEGORIES,
-  FLAG_CONSUMER_DOCS,
   FLAG_DEACTIVATED_APIS,
   FLAG_ENABLED_APIS,
   FLAG_HOSTED_APIS,
@@ -15,7 +14,6 @@ import {
 } from './types/constants';
 
 export interface AppFlags {
-  consumer_docs: boolean;
   categories: { [categoryId: string]: boolean };
   deactivated_apis: { [apiId: string]: boolean };
   enabled: { [apiId: string]: boolean };
@@ -47,7 +45,6 @@ const getFlags = (): AppFlags => {
 
   return {
     [FLAG_CATEGORIES]: apiCategories,
-    [FLAG_CONSUMER_DOCS]: process.env.REACT_APP_CONSUMER_DOCS === 'true',
     [FLAG_DEACTIVATED_APIS]: deactivatedFlags,
     [FLAG_ENABLED_APIS]: envFlags,
     [FLAG_HOSTED_APIS]: apiFlags,

--- a/src/types/constants/index.ts
+++ b/src/types/constants/index.ts
@@ -6,8 +6,9 @@ export const CURRENT_VERSION_IDENTIFIER = 'current';
 export const DEFAULT_OAUTH_API_SELECTION = 'claims';
 export const OPEN_API_SPEC_HOST: string = process.env.REACT_APP_VETSGOV_SWAGGER_API ?? '';
 
-const BACKEND_BASE_URL = `${process.env.REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL ?? ''
-  }/internal/developer-portal/public`;
+const BACKEND_BASE_URL = `${
+  process.env.REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL ?? ''
+}/internal/developer-portal/public`;
 export const APPLY_URL = `${BACKEND_BASE_URL}/developer_application`;
 export const PRODUCTION_ACCESS_URL = `${BACKEND_BASE_URL}/production_request`;
 export const CONTACT_US_URL = `${BACKEND_BASE_URL}/contact-us`;
@@ -25,7 +26,6 @@ export const PAGE_HEADER_AND_HALO_ID = 'header-halo';
 export const APPLY_INTERNAL_APIS = ['address_validation'];
 export const FLAG_API_ENABLED_PROPERTY = 'enabled';
 export const FLAG_CATEGORIES = 'categories';
-export const FLAG_CONSUMER_DOCS = 'consumer_docs';
 export const FLAG_DEACTIVATED_APIS = 'deactivated_apis';
 export const FLAG_ENABLED_APIS = 'enabled';
 export const FLAG_HOSTED_APIS = 'hosted_apis';

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-1-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:983896924fde2a1cef320acb9b58b2024413900fd67159a08bc4c60d31d7aff4
-size 124033
+oid sha256:bf4c5e04d8ca5bb49acad100e29cd5a28b6b9c192fdfe3acec191643171c6efb
+size 153241

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-2-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2a4126ebad8ac3d01e57cdd0078b5a28871fecc1f4cded7de611eba792a3535
-size 123314
+oid sha256:fc9e0f3567bbff1eb50fb8d4452c44fc520a92dc260395fa1dd9fdbad8c88aca
+size 157602

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-3-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-3-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86e1c35ebb3b0ca9349112e7417219d604e975387f7f95530c8969ccb2da5950
-size 117737
+oid sha256:8d73cf77203cc855a721808f6da7942da997f6f7eb2dfe631f7df34fff9f2882
+size 159062


### PR DESCRIPTION
### Description
This PR cleans us the codebase now that consumer docs are in production and are stable. The consumer docs feature flags have been removed from the codebase. /apply and /go-live links have been replaced in the codebase with their consumer docs equivalents. All relevant tests have been updated.
<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
