### PR TITLE
API-9848 - Grab latest release to set new release tag

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -102,7 +102,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release_builds]
     steps:
+      - id: latest_release
+        name: Get latest release with tag
+        run: |
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq '.tag_name' | sed 's/\"//g')
+          echo $LATEST_RELEASE
+          echo "::set-output name=tag::$LATEST_RELEASE"
+
       - uses: actions/checkout@v2
+        with:
+          ref: ${{steps.latest_release.outputs.tag}}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -126,7 +135,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          NEW_TAG=$(git tag --sort=-creatordate | grep ^developer-portal | head -1 | awk -F. -v OFS=. '{$NF++;print}')
+          NEW_TAG=$(git tag --sort=-creatordate | head -1 | awk -F. -v OFS=. '{$NF++;print}')
           VERSION=${NEW_TAG#"developer-portal/v"}
           gh release create $NEW_TAG
           for env in 'dev' 'staging' 'production' ; do


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-9848

Checkout needs to include the ref of the latest release to make a new one

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
