### PR TITLE
API-9848 - Change from CodeBuild releases to GitHub Actions

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -95,8 +95,8 @@ jobs:
           BUILD_ENV: ${{matrix.environment}}
           S3_ARCHIVE_BUCKET: ${{secrets.AWS_S3_ARCHIVE_BUCKET}}
         run: |
-          SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-8)
-          aws s3 cp --no-progress --acl public-read build/$BUILD_ENV.tar.bz2 s3://$S3_ARCHIVE_BUCKET/gha-$SHORT_SHA/developer-portal-$BUILD_ENV.tar.bz2
+          SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+          aws s3 cp --no-progress --acl public-read build/$BUILD_ENV.tar.bz2 s3://$S3_ARCHIVE_BUCKET/$SHORT_SHA/developer-portal-$BUILD_ENV.tar.bz2
 
   create_release:
     runs-on: ubuntu-latest
@@ -127,9 +127,9 @@ jobs:
         env:
           S3_ARCHIVE_BUCKET: ${{secrets.AWS_S3_ARCHIVE_BUCKET}}
         run: |
-          SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-8)
+          SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
           mkdir release
-          aws s3 cp --no-progress --recursive s3://$S3_ARCHIVE_BUCKET/gha-$SHORT_SHA/ release/
+          aws s3 cp --no-progress --recursive s3://$S3_ARCHIVE_BUCKET/$SHORT_SHA/ release/
 
       - name: Create the release
         env:


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-9848

This is the last of the steps required to generate releases from GitHub Actions. At this time the webhook that triggers `developer-portal-ci` is disabled so as to not double up on releases (like v0.0.778 and v0.0.779 intentionally did). Triggering the actual deploys of the packaged files still runs from `developer-portal-deplpoy` so no changes to the dev, staging, and production deploys are needed.

Should be ever return to automated deployments, either daily or perhaps on merge to master, that would need to be updated.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
