### PR TITLE
API-11439 Add a description to a prod access question

### DIFF
--- a/src/components/formField/FieldSet/FieldSet.test.tsx
+++ b/src/components/formField/FieldSet/FieldSet.test.tsx
@@ -7,6 +7,7 @@ import FieldSet from './FieldSet';
 interface RenderProps {
   legend: string;
   required?: boolean;
+  description?: string;
 }
 
 jest.mock('formik', () => ({
@@ -21,16 +22,17 @@ describe('FieldSet', () => {
       touched: {},
     }));
   });
-  const renderComponent = ({ legend, required }: RenderProps): void => {
+  const renderComponent = ({ legend, required, description }: RenderProps): void => {
     render(
       <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <FieldSet name="test" legend={legend} required={required}>
+        <FieldSet name="test" legend={legend} required={required} description={description}>
           <CheckboxRadioField type="radio" label="Yes" value="web" name="radioButton" />
           <CheckboxRadioField type="radio" label="No" value="native" name="radioButton" />
         </FieldSet>
       </Formik>,
     );
   };
+
   describe('required is not set', () => {
     it('does not include required in the legend', () => {
       renderComponent({ legend: 'Test Input' });
@@ -42,6 +44,13 @@ describe('FieldSet', () => {
     it('includes required in the label', () => {
       renderComponent({ legend: 'Test Input', required: true });
       expect(screen.getByText('(*Required)')).toBeInTheDocument();
+    });
+  });
+
+  describe('description is passed', () => {
+    it('renders the description', () => {
+      renderComponent({ description: 'A test description', legend: 'Test Input' });
+      expect(screen.getByText('A test description')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/formField/FieldSet/FieldSet.tsx
+++ b/src/components/formField/FieldSet/FieldSet.tsx
@@ -11,6 +11,7 @@ export interface FieldSetProps {
   name: string;
   required?: boolean;
   children: ReactNode;
+  description?: string;
 }
 
 const FieldSet: FC<FieldSetProps> = ({
@@ -20,6 +21,7 @@ const FieldSet: FC<FieldSetProps> = ({
   name,
   required = false,
   children,
+  description,
 }) => {
   const { errors } = useFormikContext();
   const shouldDisplayErrors = !!errors[name];
@@ -41,6 +43,11 @@ const FieldSet: FC<FieldSetProps> = ({
           {legend}
           {required && <span className="form-required-span">(*Required)</span>}
         </legend>
+        {description && (
+          <span className="vads-u-color--gray vads-u-font-size--sm">
+            {description}
+          </span>
+        )}
         <span id={errorId} className={errorMessageClass} role="alert">
           <ErrorMessage name={name} />
         </span>

--- a/src/components/formField/FieldSet/FieldSet.tsx
+++ b/src/components/formField/FieldSet/FieldSet.tsx
@@ -44,9 +44,9 @@ const FieldSet: FC<FieldSetProps> = ({
           {required && <span className="form-required-span">(*Required)</span>}
         </legend>
         {description && (
-          <span className="vads-u-color--gray vads-u-font-size--sm">
+          <p className="vads-u-color--gray vads-u-font-size--sm">
             {description}
-          </span>
+          </p>
         )}
         <span id={errorId} className={errorMessageClass} role="alert">
           <ErrorMessage name={name} />

--- a/src/containers/consumerOnboarding/components/productionAccessForm/BasicInformation.tsx
+++ b/src/containers/consumerOnboarding/components/productionAccessForm/BasicInformation.tsx
@@ -164,6 +164,7 @@ const BasicInformation: FC = () => {
             isVetFacingBorderColorClass,
           )}
           legend="Is your app Veteran-facing?"
+          description="If yes, we will ask for more details"
           legendClassName="vads-u-font-weight--normal vads-u-font-size--base"
           name="veteranFacing"
           required


### PR DESCRIPTION
### Description
This PR adds a description to the "Is your application Veteran-facing?" question in the prod access request form.

[API-11439 - Visual and Screen Reader Indication of Hidden, Conditional Fields](https://vajira.max.gov/browse/API-11439)

<img width="347" alt="Screen Shot 2021-12-08 at 10 23 11 PM" src="https://user-images.githubusercontent.com/15026647/145339397-8bc4ac2b-74cc-4c7e-90bb-940873ddfa93.png">


### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
