### PR TITLE
API-000 Removed invalid scopes from Claims CCG docs

### DIFF
--- a/src/apiDefs/data/benefits.ts
+++ b/src/apiDefs/data/benefits.ts
@@ -32,7 +32,7 @@ const benefitsApis: APIDescription[] = [
         baseAuthPath: '/oauth2/claims/system/v1',
         productionAud: '',
         sandboxAud: '',
-        scopes: ['profile', 'openid', 'offline_access', 'claim.read', 'claim.write'],
+        scopes: ['claim.read', 'claim.write'],
       },
     },
     oAuthTypes: ['AuthorizationCodeGrant', 'ClientCredentialsGrant'],


### PR DESCRIPTION
### Description

Removed invalid scopes from Claims CCG docs.  Since Client Credentials Grant flow does not have an attended user, `openid`, `profile`, and `offline_access` are not applicable.