### PR TITLE
Api 12694 fix scopes for benefits claims ccg flow

### DIFF
--- a/src/apiDefs/data/benefits.ts
+++ b/src/apiDefs/data/benefits.ts
@@ -32,7 +32,7 @@ const benefitsApis: APIDescription[] = [
         baseAuthPath: '/oauth2/claims/system/v1',
         productionAud: 'ausajojxqhTsDSVlA297',
         sandboxAud: 'ausdg7guis2TYDlFe2p7',
-        scopes: ['profile', 'openid', 'offline_access', 'claim.read', 'claim.write'],
+        scopes: ['claim.read', 'claim.write'],
       },
     },
     oAuthTypes: ['AuthorizationCodeGrant', 'ClientCredentialsGrant'],

--- a/src/apiDefs/query.test.ts
+++ b/src/apiDefs/query.test.ts
@@ -78,7 +78,7 @@ const claims: APIDescription = {
       baseAuthPath: '/oauth2/claims/system/v1',
       productionAud: 'ausajojxqhTsDSVlA297',
       sandboxAud: 'ausdg7guis2TYDlFe2p7',
-      scopes: ['profile', 'openid', 'offline_access', 'claim.read', 'claim.write'],
+      scopes: ['claim.read', 'claim.write'],
     },
   },
   oAuthTypes: ['AuthorizationCodeGrant', 'ClientCredentialsGrant'],

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-docs-client-credentials-properly-1-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-docs-client-credentials-properly-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d7520bec8167ddec681bc84a5fcb86ca39eac6b04264ed67b4dfc85e717705a
-size 487123
+oid sha256:fe38f30c9e77643be47acf6c62cfb2bd025e36c9c50e72fa7ddb68c67a4aa8e0
+size 480411

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-docs-client-credentials-properly-2-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-docs-client-credentials-properly-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf858e27462927bea553236f5e0a4ced27931381c32cd6c7b8f93bd91a74ae29
-size 470166
+oid sha256:1a0c3d5f1787d8b4137a99898fe7fcb8e9cd1de3d40d6c497878fc511c28dda9
+size 465914

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-docs-client-credentials-properly-3-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-explore-authorization-docs-client-credentials-properly-3-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfaa67f351a18c7187544c2bc2e1e5621191fb17e3b46ed4d39f5c53284c8794
-size 393031
+oid sha256:7c91dde2888302c11523d2b5b550e0d44abba7ce4237c3951f906d2c5b79f2df
+size 390758


### PR DESCRIPTION
### Description

Removed invalid scopes from Claims CCG docs. Since Client Credentials Grant flow does not have an attended user, openid, profile, and offline_access are not applicable.

### Process

- [ ] Updated unit tests and visual regression tests accordingly
