### PR TITLE
[API-12829] - Update token to allow cross repo access

### DIFF
--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -29,7 +29,7 @@ jobs:
           echo ${{ steps.get_time_string.outputs.time_string }}
           TIME_STRING=`echo ${{steps.get_time_string.outputs.time_string}}`
           echo $TIME_STRING
-          echo ${{secrets.GITHUB_TOKEN}} | gh auth login --with-token
+          echo ${{secrets.GIT_AUTO_DEPLOY_TOKEN}} | gh auth login --with-token
           gh issue list \
             -R 'department-of-veterans-affairs/lighthouse-devops-support' \
             -l 'repo: developer-portal' \

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -18,7 +18,7 @@ jobs:
           timezoneLinux: 'America/New_York'
       - name: Check for existing MRs
         run: |
-          echo ${{secrets.GITHUB_TOKEN}} | gh auth login --with-token
+          echo ${{secrets.GIT_AUTO_DEPLOY_TOKEN}} | gh auth login --with-token
           gh issue list \
             -R 'department-of-veterans-affairs/lighthouse-devops-support' \
             -l 'repo: developer-portal' \


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-12829

Changed from GITHUB_SECRET token which only has access to this repo to a PAT token which gives access to org repos including lighthouse-devops-support which is needed for this.

### Process

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
