### PR TITLE
Change code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
 # Okapi and Quokka manage the structural code for developer-portal.
-* @department-of-veterans-affairs/lighthouse-okapi @department-of-veterans-affairs/lighthouse-quokka @department-of-veterans-affairs/lighthouse-koala @department-of-veterans-affairs/lighthouse-marmoset
-
-
+* @department-of-veterans-affairs/lighthouse-okapi


### PR DESCRIPTION
### Description

Update code owners to be just Okapi to be in line with team topologies.

