### PR TITLE
[API-12829] - auto deploy cancel vs failure + release tag fix

### DIFF
--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -48,8 +48,7 @@ jobs:
           fi
           # If this errors, the MR isn't labeled "status: approved" at the time of it's scheduled deployment
           jq ".labels" issue.json | jq -e ".[] | select(.name==\"status: approved\")"
-          jq -r ".body" issue.json > issue-body.txt
-          RELEASE_TAG=`grep 'Release tag:' issue-body.txt | sed 's/Release tag: //'`
+          RELEASE_TAG=`jq -r '.body' issue.json | grep 'Release tag:' | sed 's/Release tag: //'`
           echo "::set-output name=mr_number::$MR_NUMBER"
           echo "::set-output name=release_tag::$RELEASE_TAG"
       - name: Cancel rather than fail job on above error

--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -3,7 +3,7 @@ name: Auto Deploy master to Production
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/30 15,16,17,18,19,20,21,22,23 * * 1,2,3,4,5'
+    - cron: '*/30 13,14,15,16,17,18,19,20,21,22,23 * * 1,2,3,4,5'
 
 jobs:
   run_checks_and_deploy:
@@ -24,6 +24,7 @@ jobs:
           echo "::set-output name=time_string::$TIME_STRING"
       - id: get_mr_number
         name: Grab matching deploy MR
+        continue-on-error: true
         run: |
           echo $TIME_STRING
           echo ${{ steps.get_time_string.outputs.time_string }}
@@ -34,7 +35,7 @@ jobs:
             -R 'department-of-veterans-affairs/lighthouse-devops-support' \
             -l 'repo: developer-portal' \
             --limit 1 \
-            --json id,number,state,labels,title \
+            --json id,number,state,labels,title,body \
             --jq "[.[]|select(.title==\"Deploy developer-portal to production ($TIME_STRING)\")][0]" \
             > issue.json
           cat issue.json
@@ -51,6 +52,11 @@ jobs:
           RELEASE_TAG=`grep 'Release tag:' issue-body.txt | sed 's/Release tag: //'`
           echo "::set-output name=mr_number::$MR_NUMBER"
           echo "::set-output name=release_tag::$RELEASE_TAG"
+      - name: Cancel rather than fail job on above error
+        if: steps.get_mr_number.outcome == 'failure'
+        run: |
+          gh run cancel ${{github.run_id}}
+          sleep 60
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -61,7 +67,7 @@ jobs:
           role-duration-seconds: 1200
           role-session-name: GitHubActions
 
-      - name: Build dev and staging
+      - name: Deploy to production
         run: |
           MR_NUMBER=`echo ${{steps.get_mr_number.outputs.mr_number}}`
           RELEASE_TAG=`echo ${{steps.get_mr_number.outputs.release_tag}}`


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-12829

Auto deploy jobs that don't find a matching MR will now self-cancel themselves rather than report as a failed job cluttering up people's GitHub notifications.
This also fixes the grabbing of the intended release tag from the MR body copy.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
