### PR TITLE
[API-3913] - Fix run cancel with specific repo

### DIFF
--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Cancel rather than fail job on above error
         if: steps.get_mr_number.outcome == 'failure'
         run: |
-          gh run cancel ${{github.run_id}}
+          gh run cancel ${{github.run_id}} -R 'department-of-veterans-affairs/developer-portal'
           sleep 60
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -86,9 +86,9 @@ jobs:
             if [ "COMPLETED" == "$CURRENT_PHASE" ]; then
               echo 'Build phase completed';
               START_RAW=`jq -r '.builds[0].startTime' build-status.json`
-              START_TIME=`gdate --date="$START_RAW" +"%Y/%m/%d %H:%M %Z"`
+              START_TIME=`date --date="$START_RAW" +"%Y/%m/%d %H:%M %Z"`
               END_RAW=`jq -r '.builds[0].endTime' build-status.json`
-              END_TIME=`gdate --date="$END_RAW" +"%Y/%m/%d %H:%M %Z"`
+              END_TIME=`date --date="$END_RAW" +"%Y/%m/%d %H:%M %Z"`
               printf '' > build-comment.md
               if [ "SUCCEEDED" == "$BUILD_STATUS" ]; then
                 echo 'Build successful';


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-3913

Because there's no checkout we need to tell `gh run cancel` which repo to cancel the run on.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
