### PR TITLE
Fix small but impactful typos in mailto: links

### DIFF
--- a/src/components/oauthDocs/acg/GettingStarted.tsx
+++ b/src/components/oauthDocs/acg/GettingStarted.tsx
@@ -37,7 +37,7 @@ const GettingStarted = (): JSX.Element => (
     <h3>Support</h3>
     <p>
       If you have any questions please feel free to reach out to the VA API Platform team at{' '}
-      <a href="mailto:api.va.gov">api@va.gov</a>. If you would like to report a bug or make a
+      <a href="mailto:api@va.gov">api@va.gov</a>. If you would like to report a bug or make a
       feature request, please open an issue through our <Link to="/support">Support page</Link>.
     </p>
   </>

--- a/src/components/oauthDocs/ccg/GettingStarted.tsx
+++ b/src/components/oauthDocs/ccg/GettingStarted.tsx
@@ -8,8 +8,9 @@ const GettingStarted = (): JSX.Element => (
   <>
     <SectionHeaderWrapper heading="Getting Started" id="getting-started" />
     <p>
-      After you <Link to="/apply">request sandbox access</Link>, you will need to generate your RSA key pair and convert
-      the public key into JWK format. What you generate will look similar to this:
+      After you <Link to="/apply">request sandbox access</Link>, you will need to generate your RSA
+      key pair and convert the public key into JWK format. What you generate will look similar to
+      this:
     </p>
     <CodeWrapper>
       <ReactMarkdown rehypePlugins={[highlight]}>
@@ -21,12 +22,12 @@ const GettingStarted = (): JSX.Element => (
   "alg": "RS256",
   "use": "sig"
 }
-`         }
+`}
       </ReactMarkdown>
     </CodeWrapper>
     <p>
-      Then, send this key to our support team at <a href="mailto:api.va.gov">api@va.gov</a>,
-      and we will send you a client ID.
+      Then, send this key to our support team at <a href="mailto:api@va.gov">api@va.gov</a>, and we
+      will send you a client ID.
     </p>
   </>
 );


### PR DESCRIPTION
### Description

Came across these typos during a spike on prerendering pages (API-3913) and just doing a quick PR to resolve them. I did a quick audit of all the mailto: links across the dev portal and should be good to go after this is merged.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
