### PR TITLE
[API-13873] - Fixes to MR creation script

### DIFF
--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -51,11 +51,6 @@ jobs:
           RELEASE_TAG=`jq -r '.body' issue.json | grep 'Release tag:' | sed 's/Release tag: //'`
           echo "::set-output name=mr_number::$MR_NUMBER"
           echo "::set-output name=release_tag::$RELEASE_TAG"
-      - name: Cancel rather than fail job on above error
-        if: steps.get_mr_number.outcome == 'failure'
-        run: |
-          gh run cancel ${{github.run_id}} -R 'department-of-veterans-affairs/developer-portal'
-          sleep 60
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -68,6 +63,8 @@ jobs:
 
       - id: deploy_to_production
         name: Deploy to production
+        if: steps.get_mr_number.outcome == 'success'
+        continue-on-error: true
         run: |
           MR_NUMBER=`echo ${{steps.get_mr_number.outputs.mr_number}}`
           RELEASE_TAG=`echo ${{steps.get_mr_number.outputs.release_tag}}`
@@ -110,3 +107,6 @@ jobs:
               sleep 15;
             fi
           done
+      - name: Disable Workflow till next MR is created
+        if: steps.deploy_to_production.outcome == 'success'
+        run: gh workflow disable 'Auto Deploy master to Production'

--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -107,6 +107,8 @@ jobs:
               sleep 15;
             fi
           done
+      - uses: actions/checkout@v2
+        if: steps.deploy_to_production.outcome == 'success'
       - name: Disable Workflow till next MR is created
         if: steps.deploy_to_production.outcome == 'success'
         run: gh workflow disable 'Auto Deploy master to Production'

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -42,7 +42,8 @@ jobs:
           wget https://developer.va.gov/deploy.json
           CURRENT_RELEASE_TAG=`jq -r ".release" deploy.json`
           echo $CURRENT_RELEASE_TAG
-          echo "::set-output name=current_release_tag::$CURRENT_RELEASE_TAG"
+          # echo "::set-output name=current_release_tag::$CURRENT_RELEASE_TAG"
+          echo "::set-output name=current_release_tag::developer-portal/v0.0.843"
       - id: get_current_release_from_commit_hash
         name: Get currently deployed release tag from the commit hash if last deploy didn't use the release tag
         if: steps.get_current_release_tag.outputs.current_release_tag == ''

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -42,8 +42,7 @@ jobs:
           wget https://developer.va.gov/deploy.json
           CURRENT_RELEASE_TAG=`jq -r ".release" deploy.json`
           echo $CURRENT_RELEASE_TAG
-          # echo "::set-output name=current_release_tag::$CURRENT_RELEASE_TAG"
-          echo "::set-output name=current_release_tag::developer-portal/v0.0.843"
+          echo "::set-output name=current_release_tag::$CURRENT_RELEASE_TAG"
       - id: get_current_release_from_commit_hash
         name: Get currently deployed release tag from the commit hash if last deploy didn't use the release tag
         if: steps.get_current_release_tag.outputs.current_release_tag == ''
@@ -157,4 +156,5 @@ jobs:
         if: steps.create_mr.outcome == 'success'
       - name: Enable Auto Deploy Workflow
         if: steps.create_mr.outcome == 'success'
+        continue-on-error: true
         run: gh workflow enable 'Auto Deploy master to Production'

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -145,13 +145,13 @@ jobs:
 
           cat maintenance-request.md
 
-          gh issue create \
-            -R 'department-of-veterans-affairs/lighthouse-devops-support' \
-            --title "$ISSUE_TITLE" \
-            --assignee "$TEMPLATE_ASSIGNEE" \
-            --label "$TEMPLATE_ISSUE_LABEL" \
-            --label "repo: developer-portal" \
-            --body-file maintenance-request.md
+          # gh issue create \
+          #   -R 'department-of-veterans-affairs/lighthouse-devops-support' \
+          #   --title "$ISSUE_TITLE" \
+          #   --assignee "$TEMPLATE_ASSIGNEE" \
+          #   --label "$TEMPLATE_ISSUE_LABEL" \
+          #   --label "repo: developer-portal" \
+          #   --body-file maintenance-request.md
       - name: Enable Auto Deploy Workflow
         if: steps.create_mr.outcome == 'success'
         run: gh workflow enable 'Auto Deploy master to Production'

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -152,6 +152,8 @@ jobs:
           #   --label "$TEMPLATE_ISSUE_LABEL" \
           #   --label "repo: developer-portal" \
           #   --body-file maintenance-request.md
+      - uses: actions/checkout@v2
+        if: steps.create_mr.outcome == 'success'
       - name: Enable Auto Deploy Workflow
         if: steps.create_mr.outcome == 'success'
         run: gh workflow enable 'Auto Deploy master to Production'

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -36,11 +36,6 @@ jobs:
             echo 'An MR is currently open so no new MR can be created'
             exit 1;
           fi
-      - name: Cancel rather than fail job on above error
-        if: steps.check_for_existing_mr.outcome == 'failure'
-        run: |
-          gh run cancel ${{github.run_id}}
-          sleep 60
       - id: get_current_release_tag
         name: Get current release tag from production deploy.json
         run: |
@@ -67,13 +62,32 @@ jobs:
           fi
           echo $CURRENT_RELEASE_TAG
           echo "::set-output name=current_release_tag::$CURRENT_RELEASE_TAG"
-      - name: Generate the MR body text
+      - id: get_proposed_release_tag
+        name: Get the tag name of the latest release
+        run: |
+          PROPOSED_RELEASE_TAG=`gh api /repos/department-of-veterans-affairs/developer-portal/releases/latest | jq -r ".tag_name"`
+          echo $PROPOSED_RELEASE_TAG
+          echo "::set-output name=proposed_release_tag::$PROPOSED_RELEASE_TAG"
+      - id: check_if_new_release
+        name: Check if the latest release is newer than production
+        continue-on-error: true
+        run: |
+          if [ "${{steps.unified_current_release_tag.outputs.current_release_tag}}" == "${{steps.get_proposed_release_tag.outputs.proposed_release_tag}}" ]; then
+            echo "Production already has ${{steps.get_proposed_release_tag.outputs.proposed_release_tag}} in production. Cancel MR creation."
+            exit 1;
+          else
+            echo "Production is not yet at ${{steps.get_proposed_release_tag.outputs.proposed_release_tag}}. Continuing with MR creation."
+          fi
+      - id: create_mr
+        name: Generate the MR body text and create MR
+        if: |
+          steps.check_for_existing_mr.outcome == 'success'
+          && steps.check_if_new_release.outcome == 'success'
         run: |
           wget https://raw.githubusercontent.com/department-of-veterans-affairs/developer-portal/master/.github/workflows/assets/maintenance-request.md
           TEMPLATE_ISSUE_LABEL=`grep labels maintenance-request.md | cut -f2 -d " "`
           TEMPLATE_ASSIGNEE=`grep assignees maintenance-request.md | cut -f2 -d " "`
           CURRENT_RELEASE_TAG=`echo ${{steps.unified_current_release_tag.outputs.current_release_tag}}`
-          PROPOSED_RELEASE_TAG=`gh api /repos/department-of-veterans-affairs/developer-portal/releases/latest | jq -r ".tag_name"`
           sed -i -e '1,8d' maintenance-request.md
           # Set MR template variables
           DAY_OF_THE_WEEK=`date +%A`
@@ -90,7 +104,7 @@ jobs:
           CURRENT_RELEASE_ID=`jq ".[] | select(.tag_name == \"$CURRENT_RELEASE_TAG\") | .id" releases.json`
           PROPOSED_RELEASE_PRS=`jq -r ".[] | select(.id > $CURRENT_RELEASE_ID ) | \"- \" + .name + \"\"" releases.json | sed -E 's/(.*)\#([0-9]{1,})\)/\2/'`
           echo '```' > maintainer-notes.txt
-          echo "Release tag: $PROPOSED_RELEASE_TAG" >> maintainer-notes.txt
+          echo "Release tag: ${{ steps.get_proposed_release_tag.outputs.proposed_release_tag }}" >> maintainer-notes.txt
           echo "Rollback tag: $CURRENT_RELEASE_TAG" >> maintainer-notes.txt
           echo '```' >> maintainer-notes.txt
           touch user-notes.txt
@@ -138,3 +152,6 @@ jobs:
             --label "$TEMPLATE_ISSUE_LABEL" \
             --label "repo: developer-portal" \
             --body-file maintenance-request.md
+      - name: Enable Auto Deploy Workflow
+        if: steps.create_mr.outcome == 'success'
+        run: gh workflow enable 'Auto Deploy master to Production'

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -145,13 +145,13 @@ jobs:
 
           cat maintenance-request.md
 
-          # gh issue create \
-          #   -R 'department-of-veterans-affairs/lighthouse-devops-support' \
-          #   --title "$ISSUE_TITLE" \
-          #   --assignee "$TEMPLATE_ASSIGNEE" \
-          #   --label "$TEMPLATE_ISSUE_LABEL" \
-          #   --label "repo: developer-portal" \
-          #   --body-file maintenance-request.md
+          gh issue create \
+            -R 'department-of-veterans-affairs/lighthouse-devops-support' \
+            --title "$ISSUE_TITLE" \
+            --assignee "$TEMPLATE_ASSIGNEE" \
+            --label "$TEMPLATE_ISSUE_LABEL" \
+            --label "repo: developer-portal" \
+            --body-file maintenance-request.md
       - uses: actions/checkout@v2
         if: steps.create_mr.outcome == 'success'
       - name: Enable Auto Deploy Workflow


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-13873

This PR fixes an issue where the MR creation wouldn't check to see that the proposed release version wasn't already out on production.

Other quality of life improvements:

- Jobs will no longer self-cancel when there's a condition that would stop an MR creation or auto deploy.
  - This will stop the jobs from sending GitHub notifications of a cancelled job even when only alert for failures if set.
- The auto deploy job will now only run it's scheduled tasks after an MR is created.
  - Upon successful creation of an MR `gh workflow enable 'Auto Deploy master to Production'` will run to enable the schedule to run every half hour
  - Upon successful deploy to production `gh workflow disable 'Auto Deploy master to Production'` will run to disable the schedule and not tie up a GitHub Actions runner ever half hour for 2-3 minutes.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
