### PR TITLE
[API-13873] - Allow for longer queued deploy jobs

### DIFF
--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -19,7 +19,7 @@ jobs:
       - id: get_time_string
         name: Get time string for MR search
         run: |
-          TIME_STRING=`date +"%Y/%m/%d %H:%M %Z" | sed -E 's/\:([03]{1})[0-9]{1}/:\10/g'`
+          TIME_STRING=`date +"%Y/%m/%d %H:%M %Z" | sed -E 's/\:([03]{1}|[14]{1})[0-9]{1}/:\10/g' | sed 's/\:1/:0/' | sed 's/\:4/:3/'`
           echo $TIME_STRING
           echo "::set-output name=time_string::$TIME_STRING"
       - id: get_mr_number


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-13873

GitHub Actions has to queue jobs to run at times and previously the auto deploy would support up to a 9 minute delayed start. This changes allows for up to a 19 minute delayed start as there have been a couple instances where 9 just wasn't enough time.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
