### PR TITLE
[API-14211] - Fix bearer token on CurlForm

### DIFF
--- a/src/containers/documentation/swaggerPlugins/CurlForm.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.tsx
@@ -233,6 +233,20 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
                 },
               }
             : undefined,
+          OauthFlowProduction: token
+            ? {
+                token: {
+                  access_token: token,
+                },
+              }
+            : undefined,
+          OauthFlowSandbox: token
+            ? {
+                token: {
+                  access_token: token,
+                },
+              }
+            : undefined,
           bearer_token: token,
         },
       };


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-14211

An unexpected change to `.security.OauthFlow` and `.components.securitySchemas.OauthFlow` caused the bearer token to now be reflected in the curl generator form. This accounts for new options that pass that information from the open API specs.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
