### PR TITLE
[API-14306] - Fix broken link

### DIFF
--- a/src/containers/publishing/components/publishingOnboarding/PublishingOnboarding.tsx
+++ b/src/containers/publishing/components/publishingOnboarding/PublishingOnboarding.tsx
@@ -138,8 +138,7 @@ export const PublishingOnboarding: FC = () => (
               <li>Schedule any needed publishing and maintenance check-ins</li>
               <li>Provide feedback on API documentation and spec</li>
               <li>
-                Propose route(s) for the API on{' '}
-                <Link to="https://api.va.gov">https://api.va.gov</Link>
+                Propose route(s) for the API on <a href="https://api.va.gov">https://api.va.gov</a>
               </li>
               <li>Propose where the API will live in our information architecture</li>
             </ul>


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-14306

External link was using `<Link to=` as opposed to using `<a href=` as it should be. Also confirmed no other instances of `to="http` exist in the codebase which would indicate other similar issues.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
