### PR TITLE
[API-14275] - Use security scheme type instead of name

### DIFF
--- a/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
@@ -26,7 +26,7 @@ import { SwaggerPlugins, System } from './index';
  * some tests in this file are long-running because of the expense of rendering Swagger UI,
  * so we double the timeout to 10s from the default 5s.
  */
-jest.setTimeout(10000);
+jest.setTimeout(30000);
 
 const expandOperation = (operationTag: string, description: string): HTMLElement => {
   const operationTagHeader = screen.getByRole('heading', { name: operationTag });

--- a/src/containers/documentation/swaggerPlugins/CurlForm.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.tsx
@@ -337,7 +337,7 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
           </div>
         </div>
       );
-    } else if (securityTypes.includes('oauth2')) {
+    } else if (securityTypes.includes('oauth2') || securityTypes.includes('openIdConnect')) {
       return (
         <div>
           <h3>Bearer Token:</h3>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
-    "lib": ["es6", "es2017", "esnext.array", "dom"],
+    "lib": ["es6", "es2019", "esnext.array", "dom"],
     "sourceMap": true,
     "allowJs": true,
     "jsx": "react",

--- a/unit.jest.config.js
+++ b/unit.jest.config.js
@@ -29,9 +29,7 @@ module.exports = {
     '<rootDir>/src/**/__tests__/**/*.(j|t)s?(x)',
     '<rootDir>/src/**/?(*.)(spec|test).(j|t)s?(x)',
   ],
-  testPathIgnorePatterns: [
-    '<rootDir>/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx',
-  ],
+  testPathIgnorePatterns: [],
   testEnvironment: 'jsdom',
   testURL: process.env.TEST_HOST || 'http://localhost:4444',
   transform: {


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-14275

Previously the `CurlForm` was using the component name as the conditional for how to build the fields for api key or bearer token. This change will instead read the type of the security scheme allowing for any name to be used for the security scheme's component.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
