### PR TITLE
[API-10046] - Consumer docs leave button flow update

### DIFF
--- a/src/containers/consumerOnboarding/ProductionAccess.tsx
+++ b/src/containers/consumerOnboarding/ProductionAccess.tsx
@@ -26,7 +26,7 @@ import {
   PRODUCTION_ACCESS_URL,
   yesOrNoValues,
 } from '../../types/constants';
-import { SUPPORT_CONTACT_PATH } from '../../types/constants/paths';
+import { CONSUMER_PROD_PATH, SUPPORT_CONTACT_PATH } from '../../types/constants/paths';
 import {
   BasicInformation,
   PolicyGovernance,
@@ -266,9 +266,10 @@ const ProductionAccess: FC = () => {
         key => filteredValues[key] == null && delete filteredValues[key],
       );
 
-      const policyDocuments = filteredValues.termsOfServiceURL && filteredValues.privacyPolicyURL ?
-        [filteredValues.termsOfServiceURL, filteredValues.privacyPolicyURL] :
-        undefined;
+      const policyDocuments =
+        filteredValues.termsOfServiceURL && filteredValues.privacyPolicyURL
+          ? [filteredValues.termsOfServiceURL, filteredValues.privacyPolicyURL]
+          : undefined;
 
       // delete privacyPolicyURL and termsOfServiceURL because the backend doesn't accept them,
       // instead it uses the policyDocuments array.
@@ -467,7 +468,7 @@ const ProductionAccess: FC = () => {
             visible={modal1Visible}
             onClose={(): void => setModal1Visible(false)}
             primaryButton={{
-              action: (): void => history.goBack(),
+              action: (): void => history.push(CONSUMER_PROD_PATH),
               text: 'Yes, leave',
             }}
             secondaryButton={{


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-10046

The cancel button on the Production Access Form would have some odd behaviors in some scenarios like direct links from external sites and bookmarked links. This provides a uniform path for all users when they click cancel.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
