### PR TITLE
[API-14744] - Fix support for http auth / bearer_token endpoints

### DIFF
--- a/src/containers/documentation/swaggerPlugins/CurlForm.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.tsx
@@ -224,11 +224,15 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
       const schemeKey = Object.keys(item)[0];
       if (this.state.apiKey.length > 0) {
         authorizedProperties[schemeKey] = this.state.apiKey;
-      } else if (this.state.bearerToken.length > 0 && schemeKey !== 'bearer_token') {
+      } else if (this.state.bearerToken.length > 0) {
         const token = this.isSwagger2()
           ? `Bearer: ${this.state.bearerToken}`
           : this.state.bearerToken;
-        authorizedProperties[schemeKey] = { token: { access_token: token } };
+        if (schemeKey === 'bearer_token') {
+          authorizedProperties[schemeKey] = token;
+        } else {
+          authorizedProperties[schemeKey] = { token: { access_token: token } };
+        }
       }
     });
     options.securities = {
@@ -299,6 +303,7 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
   }
 
   public authParameterContainer(): JSX.Element | null {
+    const bearerSecurityTypes = ['oauth2', 'openIdConnect', 'http'];
     const securityItems = this.security() ?? [{}];
     const securityTypes = securityItems
       .flatMap((item: { [schemeName: string]: string[] }): string[] => {
@@ -326,7 +331,7 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
           </div>
         </div>
       );
-    } else if (securityTypes.includes('oauth2') || securityTypes.includes('openIdConnect')) {
+    } else if (bearerSecurityTypes.filter(value => securityTypes.includes(value)).length > 0) {
       return (
         <div>
           <h3>Bearer Token:</h3>


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-14744

Fixes Veteran Verification APIs that use http auth with bearer tokens as #1006 broke that.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
