### PR TITLE
Changing help link to Ask VA

### DIFF
--- a/src/containers/support/FAQ.tsx
+++ b/src/containers/support/FAQ.tsx
@@ -11,9 +11,8 @@ const generalQuestions: SupportQuestion[] = [
         No - this is a support page for software developers utilizing the Veterans Affairs (VA)
         Application Programming Interface (API). If you are a Veteran seeking assistance, please
         visit the <a href="http://www.va.gov">U.S. Department of Veterans Affairs website</a> to
-        access and manage your VA benefits and health care. There are also helpful reference links
-        and Q&amp;A at the VA Inquiry Routing &amp; Information System{' '}
-        <a href="https://iris.custhelp.va.gov/app/answers/list">(IRIS)</a>.
+        access and manage your VA benefits and health care. You may also ask your question at 
+        Ask VA{' '} <a href="https://ask.va.gov/">(AVA)</a>.
       </p>
     ),
     question: 'Is this where I apply for VA benefits and access to my health records?',

--- a/src/containers/support/FAQ.tsx
+++ b/src/containers/support/FAQ.tsx
@@ -11,8 +11,8 @@ const generalQuestions: SupportQuestion[] = [
         No - this is a support page for software developers utilizing the Veterans Affairs (VA)
         Application Programming Interface (API). If you are a Veteran seeking assistance, please
         visit the <a href="http://www.va.gov">U.S. Department of Veterans Affairs website</a> to
-        access and manage your VA benefits and health care. You may also ask your question at 
-        Ask VA{' '} <a href="https://ask.va.gov/">(AVA)</a>.
+        access and manage your VA benefits and health care. You may also ask your question at Ask
+        VA <a href="https://ask.va.gov/">(AVA)</a>.
       </p>
     ),
     question: 'Is this where I apply for VA benefits and access to my health records?',


### PR DESCRIPTION
### Description

The IRIS system is no longer around within VA to answer Veteran inquiries. The system has changed over to [Ask VA](https://ask.va.gov). I have made textual changes to route users to Ask VA (AVA) instead of to IRIS.

The associated issue ticket is here: https://github.com/department-of-veterans-affairs/developer-portal/issues/1003

### Process

This isn't something that can be tested.; as the IRIS system do not fall under our responsibility as part of VA Lighthouse or va.gov; and that the decision to move to Ask VA isn't ours either.

### Requested feedback

I would like to request feedback on whether the wording of these text changes make sense.
