### PR TITLE
[API-15130] - Gracefully allow for endTime to not yet be set

### DIFF
--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -85,23 +85,29 @@ jobs:
               START_RAW=`jq -r '.builds[0].startTime' build-status.json`
               START_TIME=`date --date="$START_RAW" +"%Y/%m/%d %H:%M %Z"`
               END_RAW=`jq -r '.builds[0].endTime' build-status.json`
-              END_TIME=`date --date="$END_RAW" +"%Y/%m/%d %H:%M %Z"`
-              printf '' > build-comment.md
-              if [ "SUCCEEDED" == "$BUILD_STATUS" ]; then
-                echo 'Build successful';
+              if [ null != "$END_RAW" ]; then
+                END_TIME=`date --date="$END_RAW" +"%Y/%m/%d %H:%M %Z"`
+                printf '' > build-comment.md
+                if [ "SUCCEEDED" == "$BUILD_STATUS" ]; then
+                  echo 'Build successful';
+                else
+                  echo 'Build failed';
+                  echo 'Build Failed: please check CodeBuild for more details.' >> build-comment.md
+                fi
+                echo '```' >> build-comment.md
+                echo "Start: $START_TIME" >> build-comment.md
+                echo "End: $END_TIME" >> build-comment.md
+                echo "Execution: https://console.amazonaws-us-gov.com/codesuite/codebuild/008577686731/projects/developer-portal-deploy/build/$BUILD_ID" >> build-comment.md
+                echo '```' >> build-comment.md
+
+                gh issue comment $MR_NUMBER -R 'department-of-veterans-affairs/lighthouse-devops-support' --body-file build-comment.md
+
+                RUNNING="false"
               else
-                echo 'Build failed';
-                echo 'Build Failed: please check CodeBuild for more details.' >> build-comment.md
+                echo 'End time not yet set in `aws codebuild batch-get-builds`'
+                echo 'wait 15 seconds and try again.'
+                sleep 15;
               fi
-              echo '```' >> build-comment.md
-              echo "Start: $START_TIME" >> build-comment.md
-              echo "End: $END_TIME" >> build-comment.md
-              echo "Execution: https://console.amazonaws-us-gov.com/codesuite/codebuild/008577686731/projects/developer-portal-deploy/build/$BUILD_ID" >> build-comment.md
-              echo '```' >> build-comment.md
-
-              gh issue comment $MR_NUMBER -R 'department-of-veterans-affairs/lighthouse-devops-support' --body-file build-comment.md
-
-              RUNNING="false"
             else
               echo 'Still in progress... wait 15 seconds and retry.'
               sleep 15;


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-15130
department-of-veterans-affairs/lighthouse-devops-support#1324

My assumption here is that while the actual building process is done and the status field is marked as "completed" there are still cleanup process that are running which means that the final end hasn't been hit yet. That would cause the `.builds[0].endTime` to be unset while simultaneously allowing for `.builds[0].currentPhase` to be set to "COMPLETED"

Unfortunately there is no way to truly test this hypothesis and we can only know if this is actually the case if / when there's an error with a future build that trips up this seemingly edge case scenario.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
