### PR TITLE
[API-14968] - Content flash / scroll on navigation

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,6 +5,7 @@
     "dap.digitalgov.gov",
     "search.usa.gov",
     "www.google-analytics.com",
-    "www.googletagmanager.com"
+    "www.googletagmanager.com",
+    "googleads.g.doubleclick.net"
   ]
 }

--- a/cypress/integration/faqs.spec.js
+++ b/cypress/integration/faqs.spec.js
@@ -1,11 +1,5 @@
 /// <reference types="cypress" />
-
 // faqs.spec.js created with Cypress
-//
-// Start writing your Cypress tests below!
-// If you're unfamiliar with how Cypress works,
-// check out the link below and learn how to write your first test:
-// https://on.cypress.io/writing-first-test
 
 describe('FAQ page tests', () => {
   beforeEach(() => {

--- a/cypress/integration/page-content.spec.js
+++ b/cypress/integration/page-content.spec.js
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+// page-content.spec.js created with Cypress
+
+describe('PageContent tests', () => {
+  it("Ensure page doesn't randomly scroll", () => {
+    cy.visit('/');
+    cy.window().then($window => {
+      expect($window.scrollY).to.be.equal(0, 0);
+    });
+    cy.get('a[href="/explore"]').first().click();
+    cy.window().then($window => {
+      expect($window.scrollY).to.be.equal(0, 0);
+    });
+    cy.get('a[href="/about"]').first().click();
+    cy.window().then($window => {
+      expect($window.scrollY).to.be.equal(0, 0);
+    });
+    cy.get('a[href="/about/news"]').first().click();
+    cy.window().then($window => {
+      expect($window.scrollY).to.be.equal(0, 0);
+    });
+    cy.get('a[href="/about/news#News-releases"]').first().click();
+    cy.window().then($window => {
+      expect($window.scrollY).to.be.closeTo(973, 50);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8735,9 +8735,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -28807,7 +28807,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {

--- a/src/components/pageContent/PageContent.tsx
+++ b/src/components/pageContent/PageContent.tsx
@@ -9,7 +9,7 @@ const focusAndScroll = (elementToFocus: HTMLElement | null): void => {
     elementToFocus.focus();
   }
   if (elementToFocus?.id === 'main') {
-    setTimeout(() => window.scrollTo(0, 0), 0);
+    window.scrollTo(0, 0);
   }
 };
 
@@ -24,7 +24,7 @@ const PageContent = (): JSX.Element => {
     if (prevPath !== location.pathname) {
       // Only focus and scroll if it's not an initial page load
       if (prevPath) {
-        focusAndScroll(mainRef.current);
+        setTimeout(() => focusAndScroll(mainRef.current), 0);
       }
       prevPathRef.current = location.pathname;
     }

--- a/src/components/pageContent/PageContent.tsx
+++ b/src/components/pageContent/PageContent.tsx
@@ -5,11 +5,11 @@ import ErrorBoundaryPage from '../../containers/ErrorBoundaryPage';
 import { SiteRoutes } from '../../Routes';
 
 const focusAndScroll = (elementToFocus: HTMLElement | null): void => {
-  if (elementToFocus) {
-    elementToFocus.focus();
-  }
-  if (elementToFocus?.id === 'main') {
+  if (elementToFocus && elementToFocus.id === 'main') {
+    elementToFocus.focus({ preventScroll: true });
     window.scrollTo(0, 0);
+  } else if (elementToFocus) {
+    elementToFocus.focus();
   }
 };
 
@@ -24,7 +24,7 @@ const PageContent = (): JSX.Element => {
     if (prevPath !== location.pathname) {
       // Only focus and scroll if it's not an initial page load
       if (prevPath) {
-        setTimeout(() => focusAndScroll(mainRef.current), 0);
+        focusAndScroll(mainRef.current);
       }
       prevPathRef.current = location.pathname;
     }


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-14968

A previous bug in [API-9003](https://vajira.max.gov/browse/API-9033) caused the need to make focus and scroll separate events, this PR blocks the additional scrolling that's triggered by `.focus()` when page navigation doesn't require jumping to a specific anchor isn't called for.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
