### PR TITLE
API-14885 release notes for HLR NVC.

### DIFF
--- a/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
+++ b/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
@@ -1,7 +1,7 @@
 ### April 20, 2022
 We added functionality to our Higher-Level Review (HLR) POST endpoint to support submissions by non-Veteran claimants. This allows HLRs to be submitted by dependents of a Veteran.
 
-To learn more, read the Decision Reviews API documentation. 
+To learn more, read the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current). 
 ---
 
 ### April 18, 2022 

--- a/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
+++ b/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
@@ -1,6 +1,7 @@
 ### April 20, 2022
 We added functionality to our Higher-Level Review (HLR) POST endpoint to support submissions by non-Veteran claimants. This allows HLRs to be submitted by dependents of a Veteran.
 
+To learn more, read the Decision Reviews API documentation. 
 ---
 
 ### April 18, 2022 

--- a/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
+++ b/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
@@ -1,3 +1,8 @@
+### April 20, 2022
+We added functionality to our Higher-Level Review (HLR) POST endpoint to support submissions by non-Veteran claimants. This allows HLRs to be submitted by dependents of a Veteran.
+
+---
+
 ### April 18, 2022 
 We added 5 new endpoints to the Decision Reviews API. These endpoints allow you to: 
 


### PR DESCRIPTION
### Description
Consumers want to enable non-Veteran Claimants to submit HLRs and need to be aware of additions, deprecations, and changes to the relevant endpoints.

Details
Publish the Release Notes describing the new Non-Veteran Claimant functionality for HLR.  Darcy has approved the following:

On MONTH DD, YYYY, we added functionality to our Higher-Level Review (HLR) POST endpoint to support submissions by non-Veteran claimants. This allows HLRs to be submitted by dependents of a Veteran.

To learn more, read the [Decision Reviews API documentation](https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current).

[API-14885](https://vajira.max.gov/browse/API-14885)
