### PR TITLE
[API-13962] - Fix PR fetch from deploy.json file

### DIFF
--- a/.github/workflows/pr-builds-privileged.yml
+++ b/.github/workflows/pr-builds-privileged.yml
@@ -50,8 +50,8 @@ jobs:
       - id: get_pr_info
         name: Get PR and hash data
         run: |
-          PR_NUMBER=`jq -r '.pr' ./build/dev/build.json`
-          COMMIT_HASH=`jq -r '.commit' ./build/dev/build.json`
+          PR_NUMBER=`jq -r '.pr' ./build/dev/deploy.json`
+          COMMIT_HASH=`jq -r '.commit' ./build/dev/deploy.json`
           echo $PR_NUMBER
           echo $COMMIT_HASH
           echo "::set-output name=pr::$PR_NUMBER"


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-13962

The deploy file is `deploy.json` not `build.json`. This fixes that so the build can proceed.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
