### PR TITLE
[API-13962] - Get visual regression branch from artifact storage

### DIFF
--- a/.github/workflows/visual-regressions-privileged.yml
+++ b/.github/workflows/visual-regressions-privileged.yml
@@ -51,11 +51,19 @@ jobs:
         run: |
           PR_NUMBER=`cat ./image_diffs/pr.txt`
           COMMIT_HASH=`cat ./image_diffs/hash.txt`
+          PREVIOUS_GITHUB_HEAD_REF=`cat ./image_diffs/branch.txt`
           echo $PR_NUMBER
           echo $COMMIT_HASH
-          rm ./image_diffs/pr.txt ./image_diffs/hash.txt
+          echo $PREVIOUS_GITHUB_HEAD_REF
+          rm ./image_diffs/pr.txt ./image_diffs/hash.txt ./image_diffs/branch.txt
           echo "::set-output name=pr::$PR_NUMBER"
           echo "::set-output name=hash::$COMMIT_HASH"
+          echo "::set-output name=branch_name::$PREVIOUS_GITHUB_HEAD_REF"
+
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+          ref: ${{ steps.get_pr_info.outputs.branch_name }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -74,12 +82,13 @@ jobs:
           COMMIT_HASH: ${{steps.get_pr_info.outputs.hash}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR_NUMBER: ${{steps.get_pr_number.outputs.pr}}
+          PR_BRANCH_NAME: ${{steps.get_pr_number.outputs.branch_name}}
         run: |
-          aws s3 sync --no-progress --acl public-read image_diffs/ s3://$AWS_S3_SCREENSHOTS_BUCKET/$GITHUB_HEAD_REF/gha-$COMMIT_HASH/
+          aws s3 sync --no-progress --acl public-read image_diffs/ s3://$AWS_S3_SCREENSHOTS_BUCKET/$PR_BRANCH_NAME/gha-$COMMIT_HASH/
           report_path="image_diffs/"
           links=""
           for f in ${report_path}*; do
-            links="${links} - [${f#"${report_path}"}](https://s3-${AWS_REGION}.amazonaws.com/${AWS_S3_SCREENSHOTS_BUCKET}/$GITHUB_HEAD_REF/gha-${COMMIT_HASH}/${f#"${report_path}"}) <br />"
+            links="${links} - [${f#"${report_path}"}](https://s3-${AWS_REGION}.amazonaws.com/${AWS_S3_SCREENSHOTS_BUCKET}/$PR_BRANCH_NAME/gha-${COMMIT_HASH}/${f#"${report_path}"}) <br />"
           done
           docsLink="https://github.com/$GITHUB_REPOSITORY/blob/master/docs/testing.md#visual-regression-testing"
           comment="Visual regression testing failed. Review these diffs and then [update the snapshots locally or with GitHub Actions](${docsLink}). <br><br> ${links}"

--- a/.github/workflows/visual-regressions-unprivileged.yml
+++ b/.github/workflows/visual-regressions-unprivileged.yml
@@ -111,6 +111,7 @@ jobs:
           mkdir -p test/image_snapshots/__diff_output__;
           echo $PR_NUMBER > test/image_snapshots/__diff_output__/pr.txt
           echo $COMMIT_HASH > test/image_snapshots/__diff_output__/hash.txt
+          echo $GITHUB_HEAD_REF > test/image_snapshots/__diff_output__/branch.txt
 
       - name: Upload failed screenshots
         if: steps.visual_test.outcome == 'failure'


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-13962

Update the privileged visual regressions workflow to grab the branch name from the artifact storage like we do for pr number and hash.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
