### PR TITLE
[API-13962] - Re-download artifacts during visual regressions

### DIFF
--- a/.github/workflows/visual-regressions-privileged.yml
+++ b/.github/workflows/visual-regressions-privileged.yml
@@ -43,19 +43,51 @@ jobs:
           mkdir image_diffs
           unzip visual-test-failures.zip -d image_diffs
 
-      - name: See what's downloaded
-        run: ls -la ./image_diffs
-
       - id: get_pr_info
         name: Get PR and hash data
         run: |
           PR_NUMBER=`cat ./image_diffs/pr.txt`
           COMMIT_HASH=`cat ./image_diffs/hash.txt`
+          PREVIOUS_GITHUB_HEAD_REF=`cat ./image_diffs/branch.txt`
           echo $PR_NUMBER
           echo $COMMIT_HASH
-          rm ./image_diffs/pr.txt ./image_diffs/hash.txt
+          echo $PREVIOUS_GITHUB_HEAD_REF
+          rm ./image_diffs/pr.txt ./image_diffs/hash.txt ./image_diffs/branch.txt
           echo "::set-output name=pr::$PR_NUMBER"
           echo "::set-output name=hash::$COMMIT_HASH"
+          echo "::set-output name=branch_name::$PREVIOUS_GITHUB_HEAD_REF"
+
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+          ref: ${{ steps.get_pr_info.outputs.branch_name }}
+
+      - name: Redownload Screenshot Artifacts after branch change
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "visual-test-failures"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/visual-test-failures.zip', Buffer.from(download.data));
+
+      - name: Unzip again and delete metadata files
+        run: |
+          mkdir image_diffs
+          unzip visual-test-failures.zip -d image_diffs
+          rm ./image_diffs/pr.txt ./image_diffs/hash.txt ./image_diffs/branch.txt
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -74,12 +106,13 @@ jobs:
           COMMIT_HASH: ${{steps.get_pr_info.outputs.hash}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR_NUMBER: ${{steps.get_pr_number.outputs.pr}}
+          PR_BRANCH_NAME: ${{steps.get_pr_number.outputs.branch_name}}
         run: |
-          aws s3 sync --no-progress --acl public-read image_diffs/ s3://$AWS_S3_SCREENSHOTS_BUCKET/$GITHUB_HEAD_REF/gha-$COMMIT_HASH/
+          aws s3 sync --no-progress --acl public-read image_diffs/ s3://$AWS_S3_SCREENSHOTS_BUCKET/$PR_BRANCH_NAME/gha-$COMMIT_HASH/
           report_path="image_diffs/"
           links=""
           for f in ${report_path}*; do
-            links="${links} - [${f#"${report_path}"}](https://s3-${AWS_REGION}.amazonaws.com/${AWS_S3_SCREENSHOTS_BUCKET}/$GITHUB_HEAD_REF/gha-${COMMIT_HASH}/${f#"${report_path}"}) <br />"
+            links="${links} - [${f#"${report_path}"}](https://s3-${AWS_REGION}.amazonaws.com/${AWS_S3_SCREENSHOTS_BUCKET}/$PR_BRANCH_NAME/gha-${COMMIT_HASH}/${f#"${report_path}"}) <br />"
           done
           docsLink="https://github.com/$GITHUB_REPOSITORY/blob/master/docs/testing.md#visual-regression-testing"
           comment="Visual regression testing failed. Review these diffs and then [update the snapshots locally or with GitHub Actions](${docsLink}). <br><br> ${links}"


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-13962

Doing a second checkout won't just change the branch like I'd hoped. We need to re-download the artifacts from the previous run.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
