### PR TITLE
[API-15566] - Add placeholder openapi spec to pgd

### DIFF
--- a/src/apiDefs/data/health.ts
+++ b/src/apiDefs/data/health.ts
@@ -101,7 +101,8 @@ const healthApis: APIDescription[] = [
   },
   {
     altID: 'providerDirectory',
-    description: 'Use this API to return lists of VA providers and their information, such as locations, specialties, office hours, and more.',
+    description:
+      'Use this API to return lists of VA providers and their information, such as locations, specialties, office hours, and more.',
     docSources: [
       {
         openApiUrl: `${OPEN_API_SPEC_HOST}/services/provider-directory/v0/r4/docs`,
@@ -144,8 +145,8 @@ const healthApis: APIDescription[] = [
     description: '',
     docSources: [
       {
-        metadataUrl: '',
-        openApiUrl: '',
+        // There is no docserver URL yes for PGD so no metadata.json file yes.
+        openApiUrl: `${swaggerHost}/services/pgd/v0/r4/openapi.json`,
       },
     ],
     enabledByDefault: false,


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-15566

This bug was more of a symptom of not having an openapi spec defined for PGD. I've added https://dev-api.va.gov/services/pgd/v0/r4/openapi.json as a placeholder for the time being. What was causing the bug is that the dev portal was still showing the previous api when navigating to PGD as there was no openapi spec file to overwrite the previous one.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
