### PR TITLE
[API-15828] - Omit page 4 from Vet Confirmation prod access form

### DIFF
--- a/src/apiDefs/data/verification.ts
+++ b/src/apiDefs/data/verification.ts
@@ -27,8 +27,7 @@ const verificationApis: APIDescription[] = [
   },
   {
     altID: 'vaLetterGenerator',
-    description:
-      'Generate documents and letters for proof of existing VA benefits and status.',
+    description: 'Generate documents and letters for proof of existing VA benefits and status.',
     docSources: [
       {
         openApiUrl: `${OPEN_API_SPEC_HOST}/services/veteran-letters/v1/openapi.json`,
@@ -52,10 +51,10 @@ const verificationApis: APIDescription[] = [
     urlFragment: 'va_letter_generator',
     vaInternalOnly: true,
     veteranRedirect: {
-    linkText: 'Download VA benefit letters from VA.Gov.',
-    linkUrl: 'https://www.va.gov/records/download-va-letters/',
-    message: 'Are you a Veteran or Veteran representative?',
-  },
+      linkText: 'Download VA benefit letters from VA.Gov.',
+      linkUrl: 'https://www.va.gov/records/download-va-letters/',
+      message: 'Are you a Veteran or Veteran representative?',
+    },
   },
   {
     // adding an altID to match keys need on the backend for signup
@@ -68,7 +67,7 @@ const verificationApis: APIDescription[] = [
       },
     ],
     enabledByDefault: true,
-    lastProdAccessStep: ProdAccessFormSteps.Four,
+    lastProdAccessStep: ProdAccessFormSteps.Three,
     name: 'Veteran Confirmation API',
     openData: false,
     releaseNotes: VeteranConfirmationReleaseNotes,

--- a/src/apiDefs/query.test.ts
+++ b/src/apiDefs/query.test.ts
@@ -104,7 +104,7 @@ const confirmation: APIDescription = {
     },
   ],
   enabledByDefault: true,
-  lastProdAccessStep: ProdAccessFormSteps.Four,
+  lastProdAccessStep: ProdAccessFormSteps.Three,
   name: 'Veteran Confirmation API',
   openData: false,
   releaseNotes: VeteranConfirmationReleaseNotes,

--- a/src/containers/consumerOnboarding/RequestProductionAccess.tsx
+++ b/src/containers/consumerOnboarding/RequestProductionAccess.tsx
@@ -161,8 +161,7 @@ const RequestProductionAccess = (): JSX.Element => (
           <li>URL for your application’s privacy policy</li>
         </ul>
         <p>
-          If your application <strong>uses OAuth</strong> or the{' '}
-          <strong>Veteran Confirmation API</strong>, we will review your terms of service and
+          If your application <strong>uses OAuth</strong>, we will review your terms of service and
           privacy policies to make sure they meet our quality, plain language, and content
           standards. We may require you to make changes to your policies before your demo.
         </p>


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-15828

No longer require privacy policy and terms of service information to be submitted with Veteran Confirmation production access requests. Still requires those fields when there's another oAuth API selected on a form submission.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
