### PR TITLE
[API-16031] - ClaimsApi - Update Release Notes

### DIFF
--- a/src/content/apiDocs/benefits/claimsReleaseNotes.mdx
+++ b/src/content/apiDocs/benefits/claimsReleaseNotes.mdx
@@ -1,6 +1,10 @@
+### May 16, 2022
+
+- We corrected our validation logic for the `title10ActivationDate` in our POST "/forms/526" endpoint. The `title10ActivationDate` cannot be in the future and must be after the earliest `servicePeriod.activeDutyBeginDate`. [These changes were made in PR #9851](https://github.com/department-of-veterans-affairs/vets-api/pull/9851).
+
 ### May 10, 2022
 
-- We added a new optional request parameter to the POST "/forms/0966" endpoint, `claimant_ssn`, which is now used to include the SSN for a non-Veteran claimant.  [These changes were made in PR #918](https://github.com/department-of-veterans-affairs/vets-api/pull/9810)
+- We added a new optional request parameter to the POST "/forms/0966" endpoint, `claimant_ssn`, which is now used to include the SSN for a non-Veteran claimant.  [These changes were made in PR #9810](https://github.com/department-of-veterans-affairs/vets-api/pull/9810)
 
 ### February 15, 2022
 


### PR DESCRIPTION
### Description
- Updates Benefits ClaimsApi Release Notes to mention that the validation for the`title10ActivationDate` attribute in our POST "/forms/526" endpoint has been fixed.
- Also fixes a typo in the previous release note.