### PR TITLE
Add additional trigger for is_labeled check

### DIFF
--- a/.github/workflows/pr-requires-label.yml
+++ b/.github/workflows/pr-requires-label.yml
@@ -2,6 +2,11 @@ name: Pull Request Labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
+  workflow_run:
+    workflows: ['Automatically label PRs with content changes']
+    types:
+      - completed
+
 jobs:
   is_labeled:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This should resolve the issue where the `is_labeled` check will sometimes run before `actions/labeler@v3` in the [auto-label-content-prs.yml](https://github.com/department-of-veterans-affairs/developer-portal/blob/master/.github/workflows/auto-label-content-prs.yml) workflow. That would cause the `is_labeled` check to fail because it ran too early. This adds an additional check after the auto labeler has it's fair chance to run.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
