### PR TITLE
API-000 Correct CHAPI Auth Base Path

### DIFF
--- a/src/apiDefs/data/health.ts
+++ b/src/apiDefs/data/health.ts
@@ -48,7 +48,7 @@ const healthApis: APIDescription[] = [
     oAuth: true,
     oAuthInfo: {
       acgInfo: {
-        baseAuthPath: '/oauth2/clinical-health/v1',
+        baseAuthPath: '/oauth2/clinical-health/v2',
         scopes: [
           'profile',
           'openid',


### PR DESCRIPTION
### Description

Correct Clinical Health API Auth Base Path to V2 with the upgrade to SSOi OAuth.

### Process

- [x] Docs updated
