### PR TITLE
API-16011 Adds deprecation notice for HLR V1

### DIFF
--- a/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
+++ b/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
@@ -1,3 +1,9 @@
+## Deprecation Notice
+
+Consumers currently using the `https://api.va.gov/services/appeals/v1/decision_reviews/higher_level_reviews` endpoint, please migrate your applications to use the new Veteran Health API (FHIR) endpoints: `https://api.va.gov/services/appeals/v2/decision_reviews/higher_level_reviews` and `https://sandbox-api.va.gov/services/appeals/v2/decision_reviews/higher_level_reviews`.
+
+Both the legacy API endpoints and this legacy documentation page will no longer be accessible beginning Jun 17, 2022.
+
 ### April 20, 2022
 We added functionality to our Higher-Level Review (HLR) POST endpoint to support submissions by non-Veteran claimants. This allows HLRs to be submitted by dependents of a Veteran.
 

--- a/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
+++ b/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
@@ -4,6 +4,7 @@ We recently deprecated the higher_level_reviews endpoint for the [Decision Revie
 Consumers who were using this endpoint may instead use the following 2 new endpoints in the [Decision Reviews API V2](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current):
  - Higher_level_reviews
  - Legacy_appeals
+ ---
 
 ### April 20, 2022
 We added functionality to our Higher-Level Review (HLR) POST endpoint to support submissions by non-Veteran claimants. This allows HLRs to be submitted by dependents of a Veteran.

--- a/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
+++ b/src/content/apiDocs/appeals/decisionReviewReleaseNotes.mdx
@@ -1,8 +1,9 @@
-## Deprecation Notice
+## June 17, 2022
 
-Consumers currently using the `https://api.va.gov/services/appeals/v1/decision_reviews/higher_level_reviews` endpoint, please migrate your applications to use the new Veteran Health API (FHIR) endpoints: `https://api.va.gov/services/appeals/v2/decision_reviews/higher_level_reviews` and `https://sandbox-api.va.gov/services/appeals/v2/decision_reviews/higher_level_reviews`.
-
-Both the legacy API endpoints and this legacy documentation page will no longer be accessible beginning Jun 17, 2022.
+We recently deprecated the higher_level_reviews endpoint for the [Decision Reviews API V1](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=1.0.0). This endpoint is now removed, and its documentation is no longer available.
+Consumers who were using this endpoint may instead use the following 2 new endpoints in the [Decision Reviews API V2](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current):
+ - Higher_level_reviews
+ - Legacy_appeals
 
 ### April 20, 2022
 We added functionality to our Higher-Level Review (HLR) POST endpoint to support submissions by non-Veteran claimants. This allows HLRs to be submitted by dependents of a Veteran.


### PR DESCRIPTION
### Description
Adds deprecation notice for HLR V1.
[Ticket: API-16011](https://vajira.max.gov/browse/API-16011)
[Vets API PR](https://github.com/department-of-veterans-affairs/vets-api/pull/10063)
### Process
- [x] Docs updated