### PR TITLE
API-16786: Improve error handling when registering for CCG credentials

### DIFF
--- a/src/components/formField/TextField/TextField.tsx
+++ b/src/components/formField/TextField/TextField.tsx
@@ -15,6 +15,7 @@ export interface TextFieldProps {
   as?: FieldProps['as'];
   description?: ReactNode;
   type?: 'text' | 'email' | 'password';
+  placeholder?: string;
   disabled?: boolean;
   onKeyDown?: (event: KeyboardEvent) => void;
   innerRef?: React.RefObject<HTMLElement>;
@@ -29,6 +30,7 @@ const TextField: FC<TextFieldProps> = ({
   name,
   required = false,
   type = 'text',
+  placeholder,
   disabled = false,
   onKeyDown,
   customFieldClass,
@@ -74,6 +76,7 @@ const TextField: FC<TextFieldProps> = ({
         aria-describedby={`${errorId} ${descriptionId}`}
         aria-invalid={shouldDisplayErrors}
         type={props.as ? undefined : type}
+        placeholder={placeholder}
         disabled={disabled}
         onKeyDown={onKeyDown}
         innerRef={innerRef}

--- a/src/containers/consumerOnboarding/components/sandbox/OAuthAcgAppInfo.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/OAuthAcgAppInfo.tsx
@@ -47,7 +47,7 @@ const OAuthAcgAppInfo = (): JSX.Element => {
       <TextField
         label="OAuth Redirect URI"
         name={redirectUriInputName}
-        placeholder='http://localhost:8080/oauth/callback'
+        placeholder="http://localhost:8080/oauth/callback"
         required
         className={classNames(
           'vads-u-margin-top--4',

--- a/src/containers/consumerOnboarding/components/sandbox/OAuthAcgAppInfo.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/OAuthAcgAppInfo.tsx
@@ -47,6 +47,7 @@ const OAuthAcgAppInfo = (): JSX.Element => {
       <TextField
         label="OAuth Redirect URI"
         name={redirectUriInputName}
+        placeholder='http://localhost:8080/oauth/callback'
         required
         className={classNames(
           'vads-u-margin-top--4',

--- a/src/containers/consumerOnboarding/components/sandbox/OAuthCcgAppInfo.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/OAuthCcgAppInfo.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import classNames from 'classnames';
 
 import { TextField } from '../../../../components';
 
@@ -16,14 +15,18 @@ const OAuthCcgAppInfo = (): JSX.Element => {
       </div>
 
       <TextField
+        as="textarea"
+        placeholder='{
+  "kty": "RSA",
+  "n": "mYi1wUpwkJ1QB8...",
+  "e": "AQAB",
+  "alg": "RS256",
+  "use": "sig"
+}'
         label="OAuth Public Key"
         name={oAuthPublicKey}
         required
-        className={classNames(
-          'vads-u-margin-top--4',
-          'oauth-uri-input',
-          'xsmall-screen:vads-l-col--10',
-        )}
+        className="vads-u-margin-top--4"
       />
     </div>
   );

--- a/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
@@ -180,7 +180,7 @@ const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
             content={
               <span>
                 Need assistance? Create an issue through our <Link to="/support">Support page</Link>
-                {process.env.NODE_ENV === 'development' && submissionErrors.length > 0 && (
+                {submissionErrors.length > 0 && (
                   <ul>
                     {submissionErrors.map((item: string) => (
                       <li key={item}>{item}</li>


### PR DESCRIPTION
### Description

Displays error message from backend response in environments other than development.
Switches CCG public key field to a textarea.
Adds placeholder example text for both CCG public key field and ACG redirect uri field (to help reduce confusion)

![image](https://user-images.githubusercontent.com/31224301/175664970-1997016c-838d-4690-8948-463445b1123e.png)
