### PR TITLE
[API-17136] - Adjust majorVersion to support prefixed versions

### DIFF
--- a/src/containers/documentation/swaggerPlugins/VersionSelector.test.ts
+++ b/src/containers/documentation/swaggerPlugins/VersionSelector.test.ts
@@ -23,6 +23,11 @@ describe('VersionSelector', () => {
       expect(VersionSelector.selectors.majorVersion(state)).toBe('1');
     });
 
+    it('returns the major version number from the apiVersion when apiVersion has a text prefix', () => {
+      const state = Map<string, string>({ apiVersion: 'prefix-1.0.0' });
+      expect(VersionSelector.selectors.majorVersion(state)).toBe('1');
+    });
+
     it('returns empty when apiVersion exists does not exist in state', () => {
       const state = Map<string, string>({ apiName: 'claims' });
       expect(VersionSelector.selectors.majorVersion(state)).toBe('');

--- a/src/containers/documentation/swaggerPlugins/VersionSelector.ts
+++ b/src/containers/documentation/swaggerPlugins/VersionSelector.ts
@@ -7,10 +7,10 @@ export const VersionSelector = {
   selectors: {
     apiName: (state: Map<string, unknown>): string => state.get('apiName') as string,
     apiVersion: (state: Map<string, unknown>): string => state.get('apiVersion') as string,
-    majorVersion: createSelector(
-      apiVersion,
-      (version: string): string => (version ? version.substring(0, 1) : ''),
-    ),
+    majorVersion: createSelector(apiVersion, (version: string | undefined): string => {
+      const unPrefixedVersion = version?.split('-').pop() ?? '';
+      return version ? unPrefixedVersion.substring(0, 1) : '';
+    }),
     versionMetadata: (state: Map<string, unknown>): VersionMetadata[] | null =>
       state.get('versionMetadata') as VersionMetadata[] | null,
   },


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-17136

The prefixed api versions found in the dropdown for Patient Health API caused issues with the curlform generator because it was simply taking the first character rather than the actual major version. An oversight from #1065.

The Patient Health API versions come in `[API]-[version]` format (ex. `r4-0.0.0`) while the other APIs that are just one true API just have the version number.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
