### PR TITLE
API-16650: Secondary Text Not Using Correct Styling Rules in Prod Access Form

### DIFF
--- a/src/components/formField/FieldSet/FieldSet.tsx
+++ b/src/components/formField/FieldSet/FieldSet.tsx
@@ -43,9 +43,9 @@ const FieldSet: FC<FieldSetProps> = ({
           {required && <span className="form-required-span">(*Required)</span>}
         </legend>
         {description && (
-          <p className="vads-u-color--gray vads-u-font-size--sm">
+          <div className={classNames('vads-u-color--gray', 'vads-u-margin-top--2')}>
             {description}
-          </p>
+          </div>
         )}
         <span id={errorId} className={errorMessageClass} role="alert">
           <ErrorMessage name={name} />


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-16650

Change formatting of secondary text "If yes, we will ask for more details" in production request form to match other similar elements in the form.

![image](https://user-images.githubusercontent.com/31224301/177598588-33519838-a76f-4cf8-b39a-936f490b1e49.png)
