### PR TITLE
point health doc urls at sandbox instead of production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,6 @@
 REACT_APP_VETSGOV_SWAGGER_API=https://api.va.gov
 REACT_APP_VETSGOV_SECONDARY_SWAGGER_API=https://api.va.gov
-REACT_APP_API_URL=https://api.va.gov
+REACT_APP_API_URL=https://sandbox-api.va.gov
 REACT_APP_SALESFORCE_RETURN_URL=https://developer.va.gov/beta-success
 REACT_APP_SALESFORCE_ENV=VICPROD
 REACT_APP_TRY_IT_OUT_ENABLED=false


### PR DESCRIPTION
### Description

Health Quick Start documentation mentions several urls that currently point to production. The documentation around them talks about developing in sandbox. This code change changes the urls [here](https://developer.va.gov/explore/health/docs/quickstart) to point to sandbox.

### Note

I scoured the project to make sure this environment variable isn't being used anywhere else. I only found it used in this one document, so I think we should be safe to change it.

Additional info: this is the PR where this environment variable was introduced:
https://github.com/department-of-veterans-affairs/developer-portal/pull/158