### PR TITLE
API-18310: Add Internal Only Label to LGY API in Sandbox Access Form

### DIFF
--- a/src/apiDefs/data/loanGuaranty.ts
+++ b/src/apiDefs/data/loanGuaranty.ts
@@ -35,6 +35,7 @@ const loanGuarantyApis: APIDescription[] = [
     openData: false,
     releaseNotes: GuarantyRemittanceReleaseNotes,
     urlFragment: 'lgy_guaranty_remittance',
+    vaInternalOnly: VaInternalOnly.FlagOnly,
   },
   {
     description: 'Use the Loan Guaranty API to Manage VA Home Loans.',

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-1-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67c2fa39d08b4809bfaaef2d70cec1664da6b6df5668f10db83ac29ceefd6863
-size 142894
+oid sha256:4673b23940eb9b967fa10b1a78abff8c901a02aec13ee1a2a0dbce56abac9544
+size 144544

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-2-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd014d23c275d26f88ffbef1896e4ca8245222c0aa6cf8d7e7be5bf67953d639
-size 141416
+oid sha256:0a8e28574689f305d23d64b8dd2bf02663ac79d2605e7b94677069e7924fe419
+size 143149

--- a/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-3-snap.png
+++ b/test/image_snapshots/visual-regression-test-ts-visual-regression-test-renders-onboarding-request-sandbox-access-properly-3-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a4ed4c5047e740173926600fe181cb63dc403d101250e61fb820e66f4b15c1b
-size 132560
+oid sha256:92ef0e017b30af1073970b5ad29170eac9d9e8fdbf2818e1f6e88a8f0bf4a494
+size 134371


### PR DESCRIPTION
### Description

Flag Guaranty Remittance as "internal only" due to it having restricted access for now.
https://vajira.max.gov/browse/API-18310

### Note

All LPB environments have been updated as well.