### PR TITLE
[API-17268] - Add white-space pre-wrap for release notes fix

### DIFF
--- a/src/containers/releaseNotes/CategoryReleaseNotes.tsx
+++ b/src/containers/releaseNotes/CategoryReleaseNotes.tsx
@@ -79,7 +79,7 @@ const APIReleaseNote = ({
           <ReactMarkdown>{api.deactivationInfo.deactivationContent}</ReactMarkdown>
         </AlertBox>
       )}
-      <div id="release-notes-wrapper">
+      <div className="release-notes-wrapper">
         <ReactMarkdown>{api.releaseNotes}</ReactMarkdown>
       </div>
       <hr />

--- a/src/containers/releaseNotes/CategoryReleaseNotes.tsx
+++ b/src/containers/releaseNotes/CategoryReleaseNotes.tsx
@@ -79,7 +79,7 @@ const APIReleaseNote = ({
           <ReactMarkdown>{api.deactivationInfo.deactivationContent}</ReactMarkdown>
         </AlertBox>
       )}
-      <div>
+      <div id="release-notes-wrapper">
         <ReactMarkdown>{api.releaseNotes}</ReactMarkdown>
       </div>
       <hr />

--- a/src/containers/releaseNotes/ReleaseNotes.scss
+++ b/src/containers/releaseNotes/ReleaseNotes.scss
@@ -1,3 +1,3 @@
-#release-notes-wrapper p {
+.release-notes-wrapper p {
   white-space: 'pre-wrap';
 }

--- a/src/containers/releaseNotes/ReleaseNotes.scss
+++ b/src/containers/releaseNotes/ReleaseNotes.scss
@@ -1,0 +1,3 @@
+#release-notes-wrapper p {
+  white-space: 'pre-wrap';
+}

--- a/src/containers/releaseNotes/ReleaseNotes.tsx
+++ b/src/containers/releaseNotes/ReleaseNotes.tsx
@@ -14,6 +14,7 @@ import { ContentWithNav, SideNavEntry } from '../../components';
 import { Flag } from '../../flags';
 import { CategoryReleaseNotes, DeactivatedReleaseNotes } from './CategoryReleaseNotes';
 import ReleaseNotesOverview from './ReleaseNotesOverview';
+import './ReleaseNotes.scss';
 
 interface SideNavAPIEntryProps {
   api: APIDescription;


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-17268

Release notes that have a single line break instead of 2 which triggers a new paragraph with `react-markdown` need this to allow for new lines to appear.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
