### PR TITLE
[API-18737] - hourly signup smoke test

### DIFF
--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -1,12 +1,9 @@
-name: Cypress Smoketest
+name: Smoketest - Sandbox Form
 
 on:
   schedule:
     - cron: '20 * * * *'
   workflow_dispatch:
-
-env:
-  CYPRESS_CACHE_FOLDER: cypress/cache
 
 jobs:
   cypress_smoketest:
@@ -14,27 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - id: cache_cypress_binary
-        name: Cache Cypress binary
-        uses: actions/cache@v2
-        env:
-          cache-name: developer-portal-cypress-binary
-        with:
-          path: cypress/cache
-          key: ${{ runner.os }}-cypress-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Install Cypress
-        if: steps.cache_cypress_binary.outputs.cache-hit != 'true'
-        uses: cypress-io/github-action@v2
-        with:
-          runTests: false
-
       - name: Cypress run
-        uses: cypress-io/github-action@v2
-        with:
-          config: ignoreTestFiles=null
-          install: false
-          spec: cypress/integration/accessibility.spec.js
+        run: |
+          docker run -t -v $PWD:/e2e -w /e2e cypress/included:9.6.0 --config supportFile=false,ignoreTestFiles=null,baseUrl=https://dev-developer.va.gov -s ./cypress/integration/smoketest.spec.js
 
       - name: Upload failed screenshots
         uses: actions/upload-artifact@v2
@@ -50,19 +29,56 @@ jobs:
           name: cypress-videos
           path: cypress/videos
 
-      - uses: ruby/setup-ruby@v1
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler-cache: true
+          working-directory: 'smoketest'
+
+      - name: Install jq
+        run: |
+          sudo apt update;
+          sudo apt install -y jq;
 
       - name: Delete smoketest Okta apps
         env:
           OKTA_BASE_URL: 'https://deptva-eval.okta.com/api/v1'
           OKTA_TOKEN: ${{ secrets.OKTA_TOKEN }}
         run: |
-          acgClientId=`jq -r '.clientId' ./cypress/downloads/sandbox-form-post-response.json`;
-          ccgClientId=`jq -r '.ccgClientId' ./cypress/downloads/sandbox-form-post-response.json`;
+          cd smoketest;
+          acgClientId=`jq -r '.clientID' ../cypress/downloads/sandbox-form-post-response.json`;
+          ccgClientId=`jq -r '.ccgClientId' ../cypress/downloads/sandbox-form-post-response.json`;
           echo "Deleting ACG Client: $acgClientId"
-          ruby ./smoketest/delete-smoketest-apps.rb $acgClientId;
+          bundle exec ruby ./delete-smoketest-apps.rb 1234$acgClientId;
           echo "Deleting CCG Client: $ccgClientId"
-          ruby ./smoketest/delete-smoketest-apps.rb $ccgClientId;
+          bundle exec ruby ./delete-smoketest-apps.rb $ccgClientId;
+
+      - name: Send Slack notification for a failed signup
+        uses: slackapi/slack-github-action@v1.21.0
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: C012L7SRG66
+          # This ID is for #vaapi-alerts in Lighthouse Slack
+          payload: |
+            {
+              "text": "Developer Portal Sandbox Signup Form Smoketest: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Developer Portal Sandbox Signup Form Smoketest:\n*Status: ${{ job.status }}*\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@team_okapi please investigate"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -13,7 +13,10 @@ jobs:
 
       - name: Cypress run
         run: |
-          docker run -t -v $PWD:/e2e -w /e2e cypress/included:9.6.0 --config supportFile=false,ignoreTestFiles=null,baseUrl=https://dev-developer.va.gov -s ./cypress/integration/smoketest.spec.js
+          # working but commented
+          # docker run -t -v $PWD:/e2e -w /e2e cypress/included:9.6.0 --config supportFile=false,ignoreTestFiles=null,baseUrl=https://dev-developer.va.gov -s ./cypress/integration/smoketest.spec.js
+          # intentionally broken for initial first test after merge
+          docker run -t -v $PWD:/e2e -w /e2e cypress/included:9.6.0 --config ignoreTestFiles=null,baseUrl=https://dev-developer.va.gov -s ./cypress/integration/smoketest.spec.js
 
       - name: Upload failed screenshots
         uses: actions/upload-artifact@v2
@@ -50,7 +53,7 @@ jobs:
           acgClientId=`jq -r '.clientID' ../cypress/downloads/sandbox-form-post-response.json`;
           ccgClientId=`jq -r '.ccgClientId' ../cypress/downloads/sandbox-form-post-response.json`;
           echo "Deleting ACG Client: $acgClientId"
-          bundle exec ruby ./delete-smoketest-apps.rb 1234$acgClientId;
+          bundle exec ruby ./delete-smoketest-apps.rb $acgClientId;
           echo "Deleting CCG Client: $ccgClientId"
           bundle exec ruby ./delete-smoketest-apps.rb $ccgClientId;
 

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -80,7 +80,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "@team_okapi please investigate"
+                    "text": "@teamokapi please investigate"
                   }
                 }
               ]

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -10,9 +10,6 @@ env:
 
 jobs:
   cypress_smoketest:
-    environment:
-      name: development
-      url: https://dev-developer.va.gov
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -1,0 +1,71 @@
+name: Cypress Smoketest
+
+on:
+  schedule:
+    - cron: '20 * * * *'
+  workflow_dispatch:
+
+env:
+  CYPRESS_CACHE_FOLDER: cypress/cache
+
+jobs:
+  cypress_smoketest:
+    environment:
+      name: development
+      url: https://dev-developer.va.gov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: cache_cypress_binary
+        name: Cache Cypress binary
+        uses: actions/cache@v2
+        env:
+          cache-name: developer-portal-cypress-binary
+        with:
+          path: cypress/cache
+          key: ${{ runner.os }}-cypress-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Cypress
+        if: steps.cache_cypress_binary.outputs.cache-hit != 'true'
+        uses: cypress-io/github-action@v2
+        with:
+          runTests: false
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          config: ignoreTestFiles=null
+          install: false
+          spec: cypress/integration/accessibility.spec.js
+
+      - name: Upload failed screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+
+      - name: Upload failed videos
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-videos
+          path: cypress/videos
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+
+      - name: Delete smoketest Okta apps
+        env:
+          OKTA_BASE_URL: 'https://deptva-eval.okta.com/api/v1'
+          OKTA_TOKEN: ${{ secrets.OKTA_TOKEN }}
+        run: |
+          acgClientId=`jq -r '.clientId' ./cypress/downloads/sandbox-form-post-response.json`;
+          ccgClientId=`jq -r '.ccgClientId' ./cypress/downloads/sandbox-form-post-response.json`;
+          echo "Deleting ACG Client: $acgClientId"
+          ruby ./smoketest/delete-smoketest-apps.rb $acgClientId;
+          echo "Deleting CCG Client: $ccgClientId"
+          ruby ./smoketest/delete-smoketest-apps.rb $ccgClientId;

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ cypress/screenshots
 cypress/videos
 cypress/integration/1-getting-started
 cypress/integration/2-advanced-examples
+smoketest/vendor

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,10 @@
 {
   "baseUrl": "http://localhost:3001",
   "videoUploadOnPasses": false,
-  "ignoreTestFiles": "accessibility.spec.js",
+  "ignoreTestFiles": [
+    "accessibility.spec.js",
+    "smoketest.spec.js"
+  ],
   "blockHosts": [
     "dap.digitalgov.gov",
     "search.usa.gov",

--- a/cypress/integration/smoketest.spec.js
+++ b/cypress/integration/smoketest.spec.js
@@ -1,0 +1,46 @@
+/// <reference types="cypress" />
+
+describe('Sandbox Signup Form', () => {
+  it('Test form fillout and submission', () => {
+    cy.visit('https://dev-developer.va.gov/onboarding/request-sandbox-access');
+    cy.get('#firstNameFormField').type('Smoke');
+    cy.get('#lastNameFormField').type('Tester');
+    cy.get('#emailFormField').type('smoketester@va.gov');
+    cy.get('#organizationFormField').type('DSVA');
+
+    cy.get('#main form input[type="checkbox"]').each(async element => {
+      await element.trigger('click');
+    });
+
+    cy.get('#internalApiInfoprogramNameFormField').type('Lighthouse Smoke Test Program');
+    cy.get('#internalApiInfosponsorEmailFormField').type('smoketester.sponsor@va.gov');
+    cy.get('#oAuthApplicationTypeFormFieldweb').click();
+    cy.get('#oAuthRedirectURIFormField').type('https://developer.va.gov/oauth');
+    cy.get('#oAuthPublicKeyFormField').type(
+      '{"kid": null,"kty": "RSA","e": "AQAB","use": null,"n": "2Fb4_D4-RSjvl11txu-0s9bThk8hTo2SJauTRrS9N7piFlpGi6PBql3KzLmEu_T36YMbmTjDRPyybEEBD_XkEDuNdWSQph5Da7atfFM04IW5WH3MGPuvmaH6WpZB4Li5qESTFaMk0677uCDvOLcJmfa8bzunvbtlB4U-1WLjtDBODWiVpLlGEUofNQdX2MvTF9shtm-QqPk7K-a2Z36LrZpgcQBB1U8QtqexdaLrMgaoxmEbSgXGAc-uDkmQx1VOAsREozYZ9f1tASmOKGlxfVyBHcf6dePxq1cewpmrUfRTezky5A4K6v17uBYSpEols4ritWDRDymb7rFlUwxBjqdCjmtV18HiLIrgBNPQ2-5Jlnt-BCJg3lP_UG0r6cMO2DEtTkAkDcy4HzNuMQCrXn5ZL4kSUITrf9Mixny3vFn3aVcSNsCqLUSAfnpfRIz9oUUz5xI-FD9QsJJ1vneC8mfo-1lNaVRLNhn2t9VWY0kqhNNzS2HIktkZGzGv7gsB"}',
+      { parseSpecialCharSequences: false },
+    );
+    cy.get('#descriptionFormField').type('Just testing the form with an automated smoke test.');
+
+    let responseBody = {};
+    cy.intercept(
+      'POST',
+      'https://dev-developer.va.gov/platform-backend/v0/consumers/applications',
+      request => {
+        request.continue(response => {
+          responseBody = response.body;
+        });
+      },
+    ).as('postSandboxForm');
+    cy.get('#main button[type="submit"]').click();
+    cy.wait('@postSandboxForm')
+      .then(() => {
+        cy.writeFile('./cypress/downloads/sandbox-form-post-response.json', responseBody);
+      })
+      .then(() => {
+        expect(responseBody).to.not.have.property('errors');
+        expect(responseBody).to.have.property('ccgClientId');
+        expect(responseBody).to.have.property('clientID');
+      });
+  });
+});

--- a/smoketest/Gemfile
+++ b/smoketest/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'oktakit'

--- a/smoketest/Gemfile.lock
+++ b/smoketest/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   oktakit

--- a/smoketest/Gemfile.lock
+++ b/smoketest/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    multipart-post (2.1.1)
+    oktakit (0.3.3)
+      faraday (>= 0.17.3, < 2)
+      sawyer (>= 0.8.1, < 0.10)
+    public_suffix (4.0.6)
+    ruby2_keywords (0.0.5)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  oktakit
+
+BUNDLED WITH
+   2.3.21

--- a/smoketest/delete-smoketest-apps.rb
+++ b/smoketest/delete-smoketest-apps.rb
@@ -1,10 +1,19 @@
-require('Oktakit');
+require 'rubygems'
+require 'bundler/setup'
+require 'oktakit'
 
-id = ARGV[0];
+id = ARGV[0]
 
-client = Oktakit.new(token: ENV['OKTA_TOKEN'], api_endpoint: ENV['OKTA_BASE_URL']);
-response, http_status = client.deactivate_application(id);
-p(http_status);
-response, http_status = client.delete_application(id);
-p(http_status);
-p(response);
+client = Oktakit.new(token: ENV['OKTA_TOKEN'], api_endpoint: ENV['OKTA_BASE_URL'])
+response, http_status = client.deactivate_application(id)
+p http_status
+if http_status != 200
+  p "The app was not able to be deactivated. This is a problem."
+  exit 1
+end
+response, http_status = client.delete_application(id)
+p http_status
+if http_status != 204
+  p "The app was not able to be deleted. This is a problem."
+  exit 1
+end

--- a/smoketest/delete-smoketest-apps.rb
+++ b/smoketest/delete-smoketest-apps.rb
@@ -1,0 +1,10 @@
+require('Oktakit');
+
+id = ARGV[0];
+
+client = Oktakit.new(token: ENV['OKTA_TOKEN'], api_endpoint: ENV['OKTA_BASE_URL']);
+response, http_status = client.deactivate_application(id);
+p(http_status);
+response, http_status = client.delete_application(id);
+p(http_status);
+p(response);


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-18737

This sets up an hourly smoke test to run against the signup form at https://dev-developer.va.gov/onboarding/request-sandbox-access and, if there is a failure, alerts the team through the `#vaapi-alerts` channel in the Lighthouse Slack workspace. This test kicks off at 20 minutes past the hour, every hour, everyday.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
