### PR TITLE
[API-20646] - Change out Math.random() for static forgery token

### DIFF
--- a/src/containers/consumerOnboarding/ProductionAccess.tsx
+++ b/src/containers/consumerOnboarding/ProductionAccess.tsx
@@ -20,7 +20,7 @@ import { ProductionAccessRequest } from '../../types/forms/productionAccess';
 import { makeRequest, ResponseType } from '../../utils/makeRequest';
 import vaLogo from '../../assets/VaSeal.png';
 import hiFive from '../../assets/high-five.svg';
-import { LPB_PRODUCTION_ACCESS_URL, yesOrNoValues } from '../../types/constants';
+import { LPB_FORGERY_TOKEN, LPB_PRODUCTION_ACCESS_URL, yesOrNoValues } from '../../types/constants';
 import { CONSUMER_PROD_PATH, SUPPORT_CONTACT_PATH } from '../../types/constants/paths';
 import {
   BasicInformation,
@@ -298,8 +298,7 @@ const ProductionAccess: FC = () => {
         }
       });
       try {
-        const forgeryToken = Math.random().toString(36).substring(2);
-        setCookie('CSRF-TOKEN', forgeryToken, {
+        setCookie('CSRF-TOKEN', LPB_FORGERY_TOKEN, {
           path: LPB_PRODUCTION_ACCESS_URL,
           sameSite: 'strict',
           secure: true,
@@ -310,7 +309,7 @@ const ProductionAccess: FC = () => {
           {
             body: JSON.stringify(applicationBody),
             headers: {
-              'X-Csrf-Token': forgeryToken,
+              'X-Csrf-Token': LPB_FORGERY_TOKEN,
               accept: 'application/json',
               'content-type': 'application/json',
             },

--- a/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
+++ b/src/containers/consumerOnboarding/components/sandbox/SandboxAccessForm.tsx
@@ -8,7 +8,7 @@ import { useCookies } from 'react-cookie';
 import { Form, Formik } from 'formik';
 import { HttpErrorResponse, makeRequest, ResponseType } from '../../../../utils/makeRequest';
 import { TextField, TermsOfServiceCheckbox } from '../../../../components';
-import { LPB_APPLY_URL } from '../../../../types/constants';
+import { LPB_APPLY_URL, LPB_FORGERY_TOKEN } from '../../../../types/constants';
 import {
   ApplySuccessResult,
   DevApplicationRequest,
@@ -84,8 +84,7 @@ const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
     }
 
     try {
-      const forgeryToken = Math.random().toString(36).substring(2);
-      setCookie('CSRF-TOKEN', forgeryToken, {
+      setCookie('CSRF-TOKEN', LPB_FORGERY_TOKEN, {
         path: LPB_APPLY_URL,
         sameSite: 'strict',
         secure: true,
@@ -96,7 +95,7 @@ const SandboxAccessForm: FC<SandboxAccessFormProps> = ({ onSuccess }) => {
         {
           body: JSON.stringify(applicationBody),
           headers: {
-            'X-Csrf-Token': forgeryToken,
+            'X-Csrf-Token': LPB_FORGERY_TOKEN,
             accept: 'application/json',
             'content-type': 'application/json',
           },

--- a/src/containers/support/ContactUsForm/ContactUsForm.tsx
+++ b/src/containers/support/ContactUsForm/ContactUsForm.tsx
@@ -5,7 +5,7 @@ import { Formik, Form } from 'formik';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import { useCookies } from 'react-cookie';
 import { CheckboxRadioField } from '../../../components';
-import { LPB_CONTACT_US_URL } from '../../../types/constants';
+import { LPB_CONTACT_US_URL, LPB_FORGERY_TOKEN } from '../../../types/constants';
 import { makeRequest, ResponseType } from '../../../utils/makeRequest';
 import './ContactUsForm.scss';
 import { ContactUsFormState, FormType, SubmissionData } from '../../../types/forms/contactUsForm';
@@ -75,8 +75,7 @@ const ContactUsFormPublishing = ({ onSuccess, defaultType }: ContactUsFormProps)
     setSubmissionError(false);
 
     try {
-      const forgeryToken = Math.random().toString(36).substring(2);
-      setCookie('CSRF-TOKEN', forgeryToken, {
+      setCookie('CSRF-TOKEN', LPB_FORGERY_TOKEN, {
         path: LPB_CONTACT_US_URL,
         sameSite: 'strict',
         secure: true,
@@ -87,7 +86,7 @@ const ContactUsFormPublishing = ({ onSuccess, defaultType }: ContactUsFormProps)
         {
           body: JSON.stringify(processedData(values)),
           headers: {
-            'X-Csrf-Token': forgeryToken,
+            'X-Csrf-Token': LPB_FORGERY_TOKEN,
             accept: 'application/json',
             'content-type': 'application/json',
           },

--- a/src/types/constants/index.ts
+++ b/src/types/constants/index.ts
@@ -10,6 +10,7 @@ export const OPEN_API_SPEC_HOST: string = process.env.REACT_APP_VETSGOV_SWAGGER_
 
 const LPB_PREFIX = process.env.PUBLIC_URL ?? '';
 const LPB_BASE_URL = `${LPB_PREFIX}/platform-backend`;
+export const LPB_FORGERY_TOKEN = 'CsrfBlocker';
 export const LPB_APPLY_URL = `${LPB_BASE_URL}/v0/consumers/applications`;
 export const LPB_PRODUCTION_ACCESS_URL = `${LPB_BASE_URL}/v0/consumers/production-requests`;
 export const LPB_PROVIDERS_URL = `${LPB_BASE_URL}/v0/providers/transformations/legacy.json?environment=sandbox`;


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-20646

The initial WASA scan for the developer portal flagged the use of `Math.random()` as an issue because it is not cryptographically secure. Our use of it is not necessary and can be omitted entirely because we're using `SameSite=String` which coupled with sending the value as both a header and cookie means it cannot be sent maliciously via csrf regardless of the actual contents of the token.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
