### PR TITLE
[API-20045] - Use category veteran redirect message as fallback

### DIFF
--- a/src/containers/documentation/ApiPage.test.tsx
+++ b/src/containers/documentation/ApiPage.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import moment from 'moment';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route } from 'react-router';
@@ -253,6 +252,47 @@ describe('ApiPage', () => {
     it('renders deprecation info', () => {
       expect(screen.queryByText('test-data::: This API is deprecated')).not.toBeNull();
       expect(screen.queryByText('test-data::: This API is deactivated')).toBeNull();
+    });
+  });
+
+  describe('given api with veteran redirect', () => {
+    const apiCategory: APICategory = {
+      ...fakeCategories.lotr,
+      apis: [
+        {
+          ...lotrRingsApi,
+          veteranRedirect: {
+            linkText: 'Find a faster train',
+            linkUrl: 'https://www.va.gov/find-locations/',
+            message: 'Are you tired of waiting?',
+          },
+        },
+        {
+          ...lotrRingsApi,
+        },
+      ],
+      content: {
+        ...fakeCategories.lotr.content,
+        veteranRedirect: {
+          linkText: "Find the facility that's right for you.",
+          linkUrl: 'https://www.va.gov/find-locations/',
+          message: 'Are you a Veteran?',
+        },
+      },
+    };
+
+    it('renders API specific veteran redirect message', async () => {
+      lookupApiCategoryMock.mockReturnValue(apiCategory);
+      lookupApiByFragmentMock.mockReturnValue(apiCategory.apis[0]);
+      await renderApiPage(defaultFlags, '/explore/lotr/docs/rings');
+      expect(screen.getByText('Find a faster train')).not.toBeNull();
+    });
+
+    it('renders category veteran redirect message', async () => {
+      lookupApiCategoryMock.mockReturnValue(apiCategory);
+      lookupApiByFragmentMock.mockReturnValue(apiCategory.apis[1]);
+      await renderApiPage(defaultFlags, '/explore/lotr/docs/rings');
+      expect(screen.getByText("Find the facility that's right for you.")).not.toBeNull();
     });
   });
 });

--- a/src/containers/documentation/ApiPage.tsx
+++ b/src/containers/documentation/ApiPage.tsx
@@ -7,10 +7,7 @@ import ReactMarkdown from 'react-markdown';
 import { isApiDeactivated, isApiDeprecated } from '../../apiDefs/deprecated';
 
 import { lookupApiByFragment, lookupApiCategory } from '../../apiDefs/query';
-import {
-  APIDescription,
-  VeteranRedirectMessage as VeteranRedirectMessageProps,
-} from '../../apiDefs/schema';
+import { APIDescription, VeteranRedirectMessage } from '../../apiDefs/schema';
 import { PageHeader } from '../../components';
 import { useFlag } from '../../flags';
 
@@ -61,15 +58,23 @@ const getApi = (apiName?: string): APIDescription | null => {
   return lookupApiByFragment(apiName);
 };
 
-const VeteranRedirectMessage = ({
+const VeteranRedirectAlertMessage = ({
+  api,
   veteranRedirect,
 }: {
-  veteranRedirect: VeteranRedirectMessageProps;
+  api: APIDescription;
+  veteranRedirect: VeteranRedirectMessage;
 }): JSX.Element => (
-  <div>
-    {veteranRedirect.message}&nbsp;
-    <a href={veteranRedirect.linkUrl}>{veteranRedirect.linkText}</a>.
-  </div>
+  <AlertBox
+    status="info"
+    key={api.urlFragment}
+    className={classNames('vads-u-margin-bottom--2', 'vads-u-padding-y--1')}
+  >
+    <div>
+      {veteranRedirect.message}&nbsp;
+      <a href={veteranRedirect.linkUrl}>{veteranRedirect.linkText}</a>.
+    </div>
+  </AlertBox>
 );
 
 const ApiPage = (): JSX.Element => {
@@ -118,13 +123,7 @@ const ApiPage = (): JSX.Element => {
       </Helmet>
       <PageHeader halo={category.name} header={api.name} />
       {veteranRedirect && (
-        <AlertBox
-          status="info"
-          key={api.urlFragment}
-          className={classNames('vads-u-margin-bottom--2', 'vads-u-padding-y--1')}
-        >
-          <VeteranRedirectMessage veteranRedirect={veteranRedirect} />
-        </AlertBox>
+        <VeteranRedirectAlertMessage api={api} veteranRedirect={veteranRedirect} />
       )}
       <DeactivationMessage api={api} />
       {!isApiDeactivated(api) && <ApiDocumentation apiDefinition={api} location={location} />}

--- a/src/containers/documentation/ApiPage.tsx
+++ b/src/containers/documentation/ApiPage.tsx
@@ -7,7 +7,10 @@ import ReactMarkdown from 'react-markdown';
 import { isApiDeactivated, isApiDeprecated } from '../../apiDefs/deprecated';
 
 import { lookupApiByFragment, lookupApiCategory } from '../../apiDefs/query';
-import { APIDescription } from '../../apiDefs/schema';
+import {
+  APIDescription,
+  VeteranRedirectMessage as VeteranRedirectMessageProps,
+} from '../../apiDefs/schema';
 import { PageHeader } from '../../components';
 import { useFlag } from '../../flags';
 
@@ -58,6 +61,17 @@ const getApi = (apiName?: string): APIDescription | null => {
   return lookupApiByFragment(apiName);
 };
 
+const VeteranRedirectMessage = ({
+  veteranRedirect,
+}: {
+  veteranRedirect: VeteranRedirectMessageProps;
+}): JSX.Element => (
+  <div>
+    {veteranRedirect.message}&nbsp;
+    <a href={veteranRedirect.linkUrl}>{veteranRedirect.linkText}</a>.
+  </div>
+);
+
 const ApiPage = (): JSX.Element => {
   const location = useLocation();
   const params = useParams<APINameParam>();
@@ -65,6 +79,8 @@ const ApiPage = (): JSX.Element => {
 
   const api = getApi(params.apiName);
   const category = lookupApiCategory(params.apiCategoryKey);
+
+  const veteranRedirect = api?.veteranRedirect ?? category?.content.veteranRedirect;
 
   const tabsRegex = /tab=(r4|argonaut|dstu2)/;
   if (location.pathname === '/explore/health/docs/fhir' && tabsRegex.test(location.search)) {
@@ -101,14 +117,13 @@ const ApiPage = (): JSX.Element => {
         <title>{api.name} Documentation</title>
       </Helmet>
       <PageHeader halo={category.name} header={api.name} />
-      {api.veteranRedirect && (
+      {veteranRedirect && (
         <AlertBox
           status="info"
           key={api.urlFragment}
           className={classNames('vads-u-margin-bottom--2', 'vads-u-padding-y--1')}
         >
-          {api.veteranRedirect.message}&nbsp;
-          <a href={api.veteranRedirect.linkUrl}>{api.veteranRedirect.linkText}</a>.
+          <VeteranRedirectMessage veteranRedirect={veteranRedirect} />
         </AlertBox>
       )}
       <DeactivationMessage api={api} />


### PR DESCRIPTION
### Description

This PR updates API pages to display the category veteran redirect message as a fallback when an API specific veteran redirect message doesn't exist.

