### PR TITLE
[API-21322] - Add support for array of objects to curl form

### DIFF
--- a/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.test.tsx
@@ -461,7 +461,7 @@ describe('CurlForm', () => {
       };
 
       await testRequestBodyChange('data', dataValue);
-      await testRequestBodyChange('included', 'contestableIssue1,contestableIssue2');
+      await testRequestBodyChange('included', '[{"data":"data","foo":"bar"}]');
     });
 
     it('updates the generated curl command when request body inputs change', async () => {
@@ -472,7 +472,39 @@ describe('CurlForm', () => {
       };
 
       await updateRequestBody('data', dataValue);
-      await updateRequestBody('included', 'contestableIssue1,contestableIssue2');
+
+      const expectedCurl = `curl -X POST 'https://sandbox-api.va.gov/services/appeals/v1/decision_reviews/higher_level_reviews' \\
+--header 'X-VA-SSN: ' \\
+--header 'X-VA-Insurance-Policy-Number: ' \\
+--header 'X-VA-Birth-Date: ' \\
+--header 'X-VA-File-Number: ' \\
+--header 'Content-Type: application/json' \\
+--header 'X-VA-Service-Number: ' \\
+--header 'X-VA-Last-Name: ' \\
+--header 'X-VA-First-Name: ' \\
+--header 'X-VA-Middle-Initial: ' \\
+--data-raw '{
+  "data": {
+    "type": "higherLevelReview",
+    "attributes": {
+      "informalConference": false,
+      "sameOffice": true
+    }
+  }
+}'`;
+
+      await testCurlText(expectedCurl, operationContainer);
+    });
+
+    it('updates the generated curl command when request body inputs change with an array of objects', async () => {
+      const updateRequestBody = async (param: string, value: string): Promise<void> => {
+        const input = await findByRole(operationContainer, 'textbox', { name: param });
+        expect(input).toBeInTheDocument();
+        fireEvent.change(input, { target: { value } });
+      };
+
+      await updateRequestBody('data', dataValue);
+      await updateRequestBody('included', '[{"key":"value"},{"foo":"bar","decision":"reviews"}]');
 
       const expectedCurl = `curl -X POST 'https://sandbox-api.va.gov/services/appeals/v1/decision_reviews/higher_level_reviews' \\
 --header 'X-VA-SSN: ' \\
@@ -493,8 +525,13 @@ describe('CurlForm', () => {
     }
   },
   "included": [
-    "contestableIssue1",
-    "contestableIssue2"
+    {
+      "key": "value"
+    },
+    {
+      "foo": "bar",
+      "decision": "reviews"
+    }
   ]
 }'`;
 

--- a/src/containers/documentation/swaggerPlugins/CurlForm.tsx
+++ b/src/containers/documentation/swaggerPlugins/CurlForm.tsx
@@ -250,7 +250,17 @@ export class CurlForm extends React.Component<CurlFormProps, CurlFormState> {
     const requestBody = {};
     this.state.requestBodyProperties.forEach((property: Schema) => {
       if (property.type === 'array' && this.state.paramValues[property.name]) {
-        requestBody[property.name] = this.state.paramValues[property.name].split(',');
+        if (property.items?.type === 'object') {
+          try {
+            requestBody[property.name] = JSON.parse(
+              this.state.paramValues[property.name],
+            ) as Record<string, unknown>;
+          } catch {
+            // Do nothing as they simply don't yet have valid JSON
+          }
+        } else {
+          requestBody[property.name] = this.state.paramValues[property.name].split(',');
+        }
       } else if (property.type === 'object') {
         try {
           requestBody[property.name] = JSON.parse(this.state.paramValues[property.name]) as Record<


### PR DESCRIPTION
### Description
https://vajira.max.gov/browse/API-21322

Provide the proper handling of an array of objects in the Curl Form plugin for Swagger-UI.

See [Higher Level Reviews](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current) in Decision Reviews API for an example of it not working as expected.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
