### PR TITLE
[API-22393] - Update curlify.ts to support PATCH/PUT

### DIFF
--- a/src/containers/documentation/swaggerPlugins/curlify.test.ts
+++ b/src/containers/documentation/swaggerPlugins/curlify.test.ts
@@ -69,8 +69,8 @@ describe('curlify', () => {
   });
 
   describe('request body', () => {
-    it('does not attempt to add a body for a non-POST method', () => {
-      const methods = ['GET', 'DELETE', 'PUT'];
+    it('does not attempt to add a body for a non-POST, PUT, or PATCH method', () => {
+      const methods = ['GET', 'DELETE'];
       methods.forEach((method: string) => {
         requestSpy.mockReturnValue({
           ...defaultReq,
@@ -82,25 +82,37 @@ describe('curlify', () => {
       });
     });
 
-    it('includes the empty request body if no properties have been specified', () => {
-      const curl = curlify(reqOptions);
-      expect(curl.endsWith("--data-raw '{}'")).toBe(true);
+    it('includes the empty request body if no properties have been specified for PATCH, POST, and PUT', () => {
+      const methods = ['PATCH', 'POST', 'PUT'];
+      methods.forEach((method: string) => {
+        requestSpy.mockReturnValue({
+          ...defaultReq,
+          method,
+        });
+
+        const curl = curlify(reqOptions);
+        expect(curl.endsWith("--data-raw '{}'")).toBe(true);
+      });
     });
 
-    it('populates request body properties', () => {
+    it('populates request body properties for PATCH, POST, and PUT', () => {
+      const methods = ['PATCH', 'POST', 'PUT'];
       const testBody = {
         format: 'flat',
         ids: [1, 22, 333],
       };
 
-      requestSpy.mockReturnValue({
-        ...defaultReq,
-        body: testBody,
-      });
+      methods.forEach((method: string) => {
+        requestSpy.mockReturnValue({
+          ...defaultReq,
+          body: testBody,
+          method,
+        });
 
-      const expectedData = `--data-raw '${JSON.stringify(testBody, null, 2)}'`;
-      const curl = curlify(reqOptions);
-      expect(curl.endsWith(expectedData)).toBe(true);
+        const curl = curlify(reqOptions);
+        const expectedData = `--data-raw '${JSON.stringify(testBody, null, 2)}'`;
+        expect(curl.endsWith(expectedData)).toBe(true);
+      });
     });
   });
 });

--- a/src/containers/documentation/swaggerPlugins/curlify.ts
+++ b/src/containers/documentation/swaggerPlugins/curlify.ts
@@ -10,7 +10,7 @@ export const curlify = (requestOptions: RequestOptions): string => {
   /* eslint-enable @typescript-eslint/indent */
   const curlified = [];
   let type = '';
-  const postableMethods = ['PATCH', 'POST', 'PUT'];
+  const requestBodyMethods = ['PATCH', 'POST', 'PUT'];
   const newline = ' \\\r\n';
   const headers = request.get('headers') as Im.Map<string, string> | undefined;
   const method = request.get('method') as string;
@@ -29,7 +29,7 @@ export const curlify = (requestOptions: RequestOptions): string => {
     }
   }
 
-  if (body && postableMethods.includes(method)) {
+  if (body && requestBodyMethods.includes(method)) {
     if (type === 'multipart/form-data') {
       const bodyEntries = Object.entries(body.toJS() as { [prop: string]: unknown });
       for (const [key, value] of bodyEntries) {

--- a/src/containers/documentation/swaggerPlugins/curlify.ts
+++ b/src/containers/documentation/swaggerPlugins/curlify.ts
@@ -10,6 +10,7 @@ export const curlify = (requestOptions: RequestOptions): string => {
   /* eslint-enable @typescript-eslint/indent */
   const curlified = [];
   let type = '';
+  const postableMethods = ['PATCH', 'POST', 'PUT'];
   const newline = ' \\\r\n';
   const headers = request.get('headers') as Im.Map<string, string> | undefined;
   const method = request.get('method') as string;
@@ -28,7 +29,7 @@ export const curlify = (requestOptions: RequestOptions): string => {
     }
   }
 
-  if (body && method === 'POST') {
+  if (body && postableMethods.includes(method)) {
     if (type === 'multipart/form-data') {
       const bodyEntries = Object.entries(body.toJS() as { [prop: string]: unknown });
       for (const [key, value] of bodyEntries) {


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-22393

Surfaced with Direct Deposit Management, the CurlForm plugin, and more specifically the `curlify.ts` logic under it only supported a `requestBody` for a `POST` request. This updates it to include `PATCH`, and `PUT` methods.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
