### PR TITLE
[API-22495] - Conditionally hide prod aud from ccg auth

### DIFF
--- a/src/components/oauthDocs/ccg/GeneratingJWTContent.tsx
+++ b/src/components/oauthDocs/ccg/GeneratingJWTContent.tsx
@@ -76,12 +76,14 @@ const GeneratingJWTContent: FC<GeneratingJWTProps> = ({ apiName, productionAud, 
                 {`https://deptva-eval.okta.com/oauth2/${sandboxAud}/v1/token`}
               </a>
             </p>
-            <p>
-              For the {apiName} in production, this is:{' '}
-              <a href={`https://va.okta.com/oauth2/${productionAud}/v1/token`}>
-                {`https://va.okta.com/oauth2/${productionAud}/v1/token`}
-              </a>
-            </p>
+            {sandboxAud !== productionAud && (
+              <p>
+                For the {apiName} in production, this is:{' '}
+                <a href={`https://va.okta.com/oauth2/${productionAud}/v1/token`}>
+                  {`https://va.okta.com/oauth2/${productionAud}/v1/token`}
+                </a>
+              </p>
+            )}
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-22495

So we don't show the `sandboxAud` value on the production okta endpoint, we're hiding the production endpoint when the `sandboxAud` and `productionAud` are matching values.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
