### PR TITLE
[API-22006] - Attempt to fix Sentry Releases integration

### DIFF
--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -112,7 +112,7 @@ phases:
           if [[ "${env}" == "production" ]]; then
             export SENTRY_RELEASE=$(sentry-cli releases propose-version)
             sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-            sentry-cli releases set-commits --auto $SENTRY_RELEASE
+            sentry-cli releases set-commits --auto --ignore-missing $SENTRY_RELEASE
             sentry-cli releases finalize $SENTRY_RELEASE
           fi
         done


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->
Original Issue :: [API-22006](https://vajira.max.gov/browse/API-22006)

Sometime back in March 2022, the Sentry Releases integration stopped working.  The change in this PR attempts to get it working again by adding the `--ignore-missing` flag that is documented [here](https://docs.sentry.io/product/cli/releases/#dealing-with-missing-commits).