### PR TITLE
[API-22006] - Attempt to add source maps to Sentry Releases

### DIFF
--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -112,6 +112,7 @@ phases:
           if [[ "${env}" == "production" ]]; then
             export SENTRY_RELEASE=$(sentry-cli releases propose-version)
             sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
+            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps build/${env}/static/js --url-prefix '~/static/js'
             sentry-cli releases set-commits --auto --ignore-missing $SENTRY_RELEASE
             sentry-cli releases finalize $SENTRY_RELEASE
           fi

--- a/scripts/upload_source_map.sh
+++ b/scripts/upload_source_map.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-sentry-cli releases new $SENTRY_RELEASE
-sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps $SOURCE_DIR --url-prefix '~/static/js' --rewrite
-sentry-cli releases finalize $SENTRY_RELEASE


### PR DESCRIPTION
### Description

- Adds logic to try and upload source maps with Sentry Releases
- Removes a script (`scripts/upload_source_map.sh`) that supposedly use to do this through integration with a Jenkinsfile.  But that Jenkinsfile no longer exists and it doesn't appear that anything is referencing the script anymore.
  - The original commit where that script was created and referenced by the Jenkinsfile can be found [here](https://github.com/department-of-veterans-affairs/developer-portal/commit/b8c46813dc7bae86710d8de5bd16ce03563674c7).
