### PR TITLE
[API-22006] - Tweak the Sentry sourcemap upload path

### DIFF
--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -112,7 +112,7 @@ phases:
           if [[ "${env}" == "production" ]]; then
             export SENTRY_RELEASE=$(sentry-cli releases propose-version)
             sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps build/${env}/static/js --url-prefix '~/static/js'
+            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps ${env}/static/js --url-prefix '~/static/js'
             sentry-cli releases set-commits --auto --ignore-missing $SENTRY_RELEASE
             sentry-cli releases finalize $SENTRY_RELEASE
           fi


### PR DESCRIPTION
### Description

Tweaks the Sentry Release upload sourcemap path.

### Context
- The Sentry Release command currently looks like this ::
```
sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps build/${env}/static/js --url-prefix '~/static/js'
```

- But, it looks like maybe the file path for the JS assets look like this ::
```
...
upload: production/static/js/1.9e29021b.chunk.js to s3://developer.va.gov/static/js/1.9e29021b.chunk.js
upload: production/static/js/0.c3524841.chunk.js to s3://developer.va.gov/static/js/0.c3524841.chunk.js
upload: production/static/js/0.c3524841.chunk.js.map to s3://developer.va.gov/static/js/0.c3524841.chunk.js.map
....
```

- So I'm changing the arg from `build/${env}/static/js` -> `${env}/static/js`