### PR TITLE
[API-22006] - Make Sentry Release name match GitHub Release Name

### DIFF
--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -110,11 +110,11 @@ phases:
           eval aws s3 sync --no-progress --delete --acl public-read ${env}/ s3://\${$S3_BUCKET}/ || exit 1
           slackpost.sh -t success "Deployment of ${RELEASE}${COMMIT_HASH} to ${env} was completed."
           if [[ "${env}" == "production" ]]; then
-            export SENTRY_RELEASE=$(sentry-cli releases propose-version)
-            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps ${env}/static/js --url-prefix '~/static/js'
-            sentry-cli releases set-commits --auto --ignore-missing $SENTRY_RELEASE
-            sentry-cli releases finalize $SENTRY_RELEASE
+            export SENTRY_RELEASE_NAME=$(echo $RELEASE | sed 's|/|-|')
+            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE_NAME
+            sentry-cli releases files $SENTRY_RELEASE_NAME upload-sourcemaps ${env}/static/js --url-prefix '~/static/js'
+            sentry-cli releases set-commits --auto --ignore-missing $SENTRY_RELEASE_NAME
+            sentry-cli releases finalize $SENTRY_RELEASE_NAME
           fi
         done
   post_build:


### PR DESCRIPTION
### Description

Attempts to give Sentry Releases the same name as the GitHub Release name.