### PR TITLE
[API-24179] - Add v1 banner to Appeals Status API

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -127,6 +127,13 @@ const Header = (): JSX.Element => {
             className="vads-u-margin-top--0"
           />
         </Flag>
+        {location.pathname === '/explore/appeals/docs/appeals' && (
+          <va-alert status="info" visible>
+            <h3 slot="headline">
+              A new version of Appeals Status API (v1) will launch later this year.
+            </h3>
+          </va-alert>
+        )}
         {location.pathname === '/explore/facilities/docs/facilities' && (
           <va-alert status="info" visible>
             <h3 slot="headline">


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-24179

Adds a banner to the Appeals Status API about the future v1 version.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
