### PR TITLE
[API-24155] - Add GH issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Developer Portal Support
+    url: https://developer.va.gov/support/contact-us
+    about: Support form for software developers and API publishers.


### PR DESCRIPTION
### Description
- Adds a GitHub issue template config to the repo.  This will allow us to direct contributors to the DevPortal's ["Developer Portal Support"](https://developer.va.gov/support/contact-us) page when creating new issues in the repo.