### PR TITLE
[API-19485] - Fix / upgrade cypress smoketest

### DIFF
--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -73,7 +73,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         if: failure()
         env:
-          SLACK_BOT_TOKEN: BlockWebhook-${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: C012L7SRG66
           # This ID is for #vaapi-alerts in Lighthouse Slack

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
 

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -11,7 +11,6 @@ env:
 jobs:
   cypress_smoketest:
     runs-on: ubuntu-latest
-    container: cypress/included:12.8.1
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           node-version: 18
 
-      - name: NPM Symlink for TypeScript
-        run: ln -s /usr/local/lib/node_modules ./node_modules
+      - name: NPM Install
+        run: npm ci
 
       - name: Cypress run
         uses: cypress-io/github-action@v5

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -21,12 +21,13 @@ jobs:
         with:
           node-version: 18
 
-      - name: NPM Install
-        run: npm ci
+      - name: NPM Symlink for TypeScript
+        run: ln -s /usr/local/lib/node_modules ./node_modules
 
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
+          baseUrl: https://dev-developer.va.gov
           install: false
           spec: cypress/e2e/smoketest.cy.js
 

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -16,10 +16,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Cypress run
-        run: |
-          docker run -t -v $PWD:/e2e -w /e2e cypress/included:9.6.0 --config supportFile=false,ignoreTestFiles=null,baseUrl=https://dev-developer.va.gov -s ./cypress/integration/smoketest.spec.js
-
-      - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
           install: false

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: 18
 
+      - name: NPM Install
+        run: npm ci
+
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
-          baseUrl: https://dev-developer.va.gov
+          config: baseUrl=https://dev-developer.va.gov
           install: false
           spec: cypress/e2e/smoketest.cy.js
 

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -5,15 +5,26 @@ on:
     - cron: '20 * * * *'
   workflow_dispatch:
 
+env:
+  CYPRESS_SINGLE_SPEC: true
+
 jobs:
   cypress_smoketest:
     runs-on: ubuntu-latest
+    container: cypress/included:12.8.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cypress run
         run: |
           docker run -t -v $PWD:/e2e -w /e2e cypress/included:9.6.0 --config supportFile=false,ignoreTestFiles=null,baseUrl=https://dev-developer.va.gov -s ./cypress/integration/smoketest.spec.js
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        with:
+          install: false
+          spec: cypress/e2e/smoketest.cy.js
+          wait-on: https://dev-developer.va.gov
 
       - name: Upload failed screenshots
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -13,14 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/included:12.8.1
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
 
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
           install: false
           spec: cypress/e2e/smoketest.cy.js
-          wait-on: https://dev-developer.va.gov
 
       - name: Upload failed screenshots
         uses: actions/upload-artifact@v3
@@ -65,7 +70,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         if: failure()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: BlockWebhook-${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: C012L7SRG66
           # This ID is for #vaapi-alerts in Lighthouse Slack

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -23,14 +23,14 @@ jobs:
           wait-on: https://dev-developer.va.gov
 
       - name: Upload failed screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
 
       - name: Upload failed videos
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-videos
@@ -62,7 +62,7 @@ jobs:
           bundle exec ruby ./delete-smoketest-apps.rb $ccgClientId;
 
       - name: Send Slack notification for a failed signup
-        uses: slackapi/slack-github-action@v1.21.0
+        uses: slackapi/slack-github-action@v1.23.0
         if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
### Description

https://vajira.max.gov/browse/API-19485

Update to node 18 broke the Cypress smoketest on the sandbox signup form on dev. This resolves that oversight.

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
