### PR TITLE
Resolve sandbox access for mismatching altId and urlFragment

### DIFF
--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -214,8 +214,8 @@ phases:
           # 301 redirects related to IA updates
           for REDIRECT in `grep -v '#' ./redirects.txt`; do
             ORIGINAL=${REDIRECT%|*}
-            TARGET="https://${S3_BUCKET}${REDIRECT#*|}"
-            eval aws s3api put-object --website-redirect-location $TARGET --bucket $S3_BUCKET --key $ORIGINAL --acl public-read
+            TARGET="https://${$S3_BUCKET}${REDIRECT#*|}"
+            eval aws s3api put-object --website-redirect-location $TARGET --bucket ${$S3_BUCKET} --key $ORIGINAL --acl public-read
           done
         done
   post_build:

--- a/src/containers/documentation/RequestSandboxAccess.tsx
+++ b/src/containers/documentation/RequestSandboxAccess.tsx
@@ -3,12 +3,14 @@ import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { SandboxAccessForm } from '@department-of-veterans-affairs/sandbox-access-form';
 import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
 import { PageHeader } from '../../components';
 import { LPB_APPLY_URL } from '../../types/constants';
 import { ApplySuccessResult } from '../../types/forms/apply';
 import {
   AUTHORIZATION_CCG_PATH,
   AUTHORIZATION_PKCE_PATH,
+  SUPPORT_CONTACT_PATH,
   TERMS_OF_SERVICE_PATH,
 } from '../../types/constants/paths';
 import { APIUrlSlug } from '../../types';
@@ -70,19 +72,28 @@ const RequestSandboxAccess: React.FunctionComponent = () => {
           <p className="vads-u-margin-top--3">
             Submit this form to get instant access to test data for this API.
           </p>
-          <SandboxAccessForm
-            apiIdentifier={api.urlFragment}
-            authTypes={authTypes}
-            onFailure={onFormFailure}
-            onSuccess={setSuccessResults}
-            urls={{
-              acgPkceAuthUrl: AUTHORIZATION_PKCE_PATH,
-              ccgPublicKeyUrl: AUTHORIZATION_CCG_PATH,
-              postUrl: LPB_APPLY_URL,
-              termsOfServiceUrl: TERMS_OF_SERVICE_PATH,
-            }}
-            key={api.urlFragment}
-          />
+          {api.altID ? (
+            <SandboxAccessForm
+              apiIdentifier={api.altID}
+              authTypes={authTypes}
+              onFailure={onFormFailure}
+              onSuccess={setSuccessResults}
+              urls={{
+                acgPkceAuthUrl: AUTHORIZATION_PKCE_PATH,
+                ccgPublicKeyUrl: AUTHORIZATION_CCG_PATH,
+                postUrl: LPB_APPLY_URL,
+                termsOfServiceUrl: TERMS_OF_SERVICE_PATH,
+              }}
+              key={api.urlFragment}
+            />
+          ) : (
+            <va-alert status="error" visible>
+              <p>
+                There is an error with this Sandbox Access Form. Please{' '}
+                <Link to={SUPPORT_CONTACT_PATH}>contact support</Link> for additional assistance.
+              </p>
+            </va-alert>
+          )}
         </>
       )}
     </>


### PR DESCRIPTION
### Description

This resolves the issue where the form was posting the urlFragment and not the altId. Most older APIs have these values matching which caused many false positives.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.

If you're making non-content updates make sure you have read the development guide: https://github.com/department-of-veterans-affairs/developer-portal/blob/master/docs/development.md
-->

### Process

<!--
All new components should have associated unit tests, at minimum. If your PR is modifying any
existing component with little or no testing can you improve the testing in that corner of the codebase?

Is your change something that needs an update in the documentation? (Referring specifically to documentation
for operating the developer portal and not documentation for that APIs that live on the developer portal).

If neither of these checks are relevant to your PR (like changes that only affect content) you can delete them.
-->

- [ ] Tests added or updated for change
- [ ] Docs updated
  - [ ] If you have made structural changes to the site, the [Developer Portal Content Types](https://community.max.gov/x/qUwOg) docs have been updated
  - [ ] If you have made/confirmed any decisions about user interactions and accessibility, the [Accessible Component Design](https://community.max.gov/x/xS8mgg) docs have been updated
- [ ] Accessibility concerns have been considered and addressed
  <!-- Deque's axe browser extension: https://www.deque.com/axe/browser-extensions/ -->
  - [ ] If you've made any UI changes, you've run an axe check using the axe browser extension that reported no new issues

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
