### PR TITLE
[API-28414] Display banner on version select

### DIFF
--- a/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
+++ b/src/containers/documentation/swaggerPlugins/VersionSelect.tsx
@@ -95,9 +95,11 @@ export default class VersionSelect extends React.PureComponent<
 
     let apiStatus;
     if (this.props.version === 'current') {
-      apiStatus = this.props.versions?.[0].label ?? '';
+      apiStatus = this.props.versions?.[0].label ?? this.props.versions?.[0].version;
     } else {
-      apiStatus = this.getVersionMetadataByProp('version', this.props.version)?.label;
+      apiStatus =
+        this.getVersionMetadataByProp('version', this.props.version)?.label ??
+        this.getVersionMetadataByProp('version', this.props.version)?.version;
     }
 
     return (


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

[API-28414](https://jira.devops.va.gov/browse/API-28414)
This PR fixes displaying the API version banner on version change for all APIs. Previously, the banner was incorrectly only displaying for FHIR API version changes.

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
