### PR TITLE
Add sudo for apt command

### DIFF
--- a/.github/workflows/visual-regressions-privileged.yml
+++ b/.github/workflows/visual-regressions-privileged.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion != 'success' }}
     steps:
       - name: Install git-lfs
-        run: apt update && apt install git-lfs
+        run: sudo apt update && apt install git-lfs
       - uses: actions/checkout@v3
         with:
           lfs: true


### PR DESCRIPTION
### Description

https://oddball.slack.com/archives/C02GF07P3QU/p1691511274010189

Spotted that visual regressions were not posting back to the PRs on this Slack thread. Because of a change to the underlying GHA worker machine, adding sudo should fix the [permissions issue](https://github.com/department-of-veterans-affairs/developer-portal/actions/runs/5798933462/job/15717788506).

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
