### PR TITLE
[API-28055] - Remove webfactory/ssh-agent

### DIFF
--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -20,11 +20,6 @@ jobs:
         with:
           node-version: 18
 
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
-
       - name: NPM Install
         run: npm ci
 

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -35,11 +35,6 @@ jobs:
         run: |
           apt update && apt install openssh-client python3 -y && ln -s /usr/bin/python3 /usr/bin/python
 
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
-
       - name: Start Fake LPB Server
         run: ./scripts/fake_lpb.sh
 
@@ -91,11 +86,6 @@ jobs:
       - name: Install python and openssh-client env
         run: |
           apt update && apt install openssh-client python3 -y && ln -s /usr/bin/python3 /usr/bin/python
-
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
 
       - name: Start Fake LPB Server
         run: ./scripts/fake_lpb.sh

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -8,6 +8,10 @@ on:
 env:
   REACT_APP_VETSGOV_SWAGGER_API: http://localhost:3001
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   end-to-end:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-visual-regressions.yml
+++ b/.github/workflows/generate-visual-regressions.yml
@@ -81,11 +81,6 @@ jobs:
       - name: Delete all old snapshots
         run: rm -f test/image_snapshots/visual.cy.js/*
 
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
-
       - id: visual_test
         continue-on-error: true
         name: Cypress run

--- a/.github/workflows/generate-visual-regressions.yml
+++ b/.github/workflows/generate-visual-regressions.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   update_visual_regressions:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -23,11 +23,6 @@ jobs:
           echo $NODE_VERSION
           echo "node_version=$NODE_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
-
       - name: Install dependencies
         run: npm ci
 
@@ -44,11 +39,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -5,6 +5,10 @@ on:
     branches: [master, api-11566/information-architecture]
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -40,11 +40,6 @@ jobs:
           echo $GIT_HASH
           echo "hash=$GIT_HASH" >> $GITHUB_OUTPUT
 
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
-
       - name: Install dependencies
         run: npm ci
 
@@ -58,11 +53,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
 
       - name: Install dependencies
         run: npm ci
@@ -93,11 +83,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -9,6 +9,10 @@ env:
   S3_REVIEW_BUCKET: review-developer-va-gov
   PREVIEW_SENTRY_DSN: http://dc7d5ebec20e474c80f8150c399d2955@sentry.vfs.va.gov/26
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   install:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -43,11 +43,6 @@ jobs:
           GIT_HASH=$(/bin/bash -c "git log --oneline | cut -f3 -d \" \" | cut -c1-7")
           echo "hash=$GIT_HASH" >> $GITHUB_OUTPUT
 
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
-
       - name: Install dependencies
         run: npm ci
 
@@ -64,11 +59,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/visual-regressions-unprivileged.yml
+++ b/.github/workflows/visual-regressions-unprivileged.yml
@@ -6,6 +6,10 @@ on:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-regressions-unprivileged.yml
+++ b/.github/workflows/visual-regressions-unprivileged.yml
@@ -61,11 +61,6 @@ jobs:
       - name: Install python and openssh-client env
         run: |
           apt update && apt install python3 openssh-client -y && ln -s /usr/bin/python3 /usr/bin/python
-
-      - name: Add private key for sandbox-access-form repo
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SANDBOX_FORM_SSH_KEY }}
   
       - name: Start Fake LPB Server
         run: ./scripts/fake_lpb.sh


### PR DESCRIPTION
### Description

https://jira.devops.va.gov/browse/API-28055

Remove the webfactort/ssh-agent GitHub workflow action as [sandbox-access-form repo](https://github.com/department-of-veterans-affairs/va-api-sandbox-access-form) is now open sourced so an SSH key is no longer needed to install the package.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
