### PR TITLE
Display veteran resources modal above content

### DIFF
--- a/src/components/veteranResources/VeteranResources.scss
+++ b/src/components/veteranResources/VeteranResources.scss
@@ -1,6 +1,8 @@
 @import '../../styles/variables';
 
 .veteran-resources-modal {
+  z-index: 1001 !important;
+
   .va-modal-inner {
     overflow-y: auto;
     width: 100%;


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->
This PR updates the z-index of the veteran resources modal to display correctly.
### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
