### PR TITLE
Display all modals on top

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -54,7 +54,9 @@ h4 {
   font-family: 'Bitter', serif;
   color: $color-gray-dark;
 }
+
 .sans-serif-headers {
+
   h1,
   h2,
   h3,
@@ -99,7 +101,7 @@ a {
 *:focus,
 a:focus,
 .usa-focus,
-[type='checkbox']:focus + label::before {
+[type='checkbox']:focus+label::before {
   @include focus-outline;
 }
 
@@ -118,6 +120,7 @@ input:focus::placeholder {
   h3 {
     margin: 0 !important;
   }
+
   p {
     margin: 0;
   }
@@ -137,4 +140,8 @@ input:focus::placeholder {
 
 #va-network-modal .loading-indicator {
   margin-bottom: 2rem;
+}
+
+.va-modal {
+  z-index: 1001 !important;
 }


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->
This PR updates the z-index for any modal using the `va-modal` class to display above all other elements.

Origin:
![unnamed](https://github.com/department-of-veterans-affairs/developer-portal/assets/36863582/7799f70a-eb54-48d9-b8ea-a3c11c8fa616)

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
