### PR TITLE
[API-29486] - Add GTM environments to dev/staging

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -68,6 +68,17 @@ process.env.NODE_PATH = (process.env.NODE_PATH || '')
 // injected into the application via DefinePlugin in Webpack configuration.
 const REACT_APP = /^REACT_APP_/i;
 
+const gtmEnvironmentSuffix = () => {
+  switch (process.argv[2] || 'dev') {
+    case 'dev':
+      return '&gtm_auth=8za7ZBmPNgdQY0eQK6NxxA&gtm_preview=env-9&gtm_cookies_win=x';
+    case 'staging':
+      return '&gtm_auth=iwbn38RwHI2gYo7oSgJZzg&gtm_preview=env-10&gtm_cookies_win=x';
+    default:
+      return '';
+  }
+}
+
 // `publicUrl` can be a URL or a path because it is used as a string prefix in
 // the public/index.html template. Either way it should not have a trailing
 // slash in order to align with the assumptions of the templates.
@@ -88,6 +99,9 @@ function getClientEnvironment(publicUrl) {
         // This should only be used as an escape hatch. Normally you would put
         // images into the `src` and `import` them in code to get their paths.
         PUBLIC_URL: publicUrl,
+        // To support multiple Google Tag Manager environments we need to supply
+        // a suffix to the script's URL for those lower environment tags to load
+        GTM_ENVIRONMENT_SUFFIX: gtmEnvironmentSuffix(),
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+'%GTM_ENVIRONMENT_SUFFIX%';f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-P39RXZWL');</script>
     <!-- End Google Tag Manager -->
 
@@ -35,7 +35,7 @@
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P39RXZWL"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P39RXZWL%GTM_ENVIRONMENT_SUFFIX%"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->    
     <noscript>


### PR DESCRIPTION
### Description

https://jira.devops.va.gov/browse/API-29486

This change updates the webpack environment injection to include %GTM_ENVIRONMENT_SUFFIX% so that environment information can be added to the GTM embed script on the different environments.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
