### PR TITLE
[API-29516] - Patch failure scenario on smoketest

### DIFF
--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -23,8 +23,10 @@ jobs:
       - name: NPM Install
         run: npm ci
 
-      - name: Cypress run
+      - id: cypress_run
+        name: Cypress run
         uses: cypress-io/github-action@v5
+        continue-on-error: true
         with:
           config: baseUrl=https://dev-developer.va.gov
           install: false
@@ -32,14 +34,14 @@ jobs:
 
       - name: Upload failed screenshots
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: steps.cypress_run.outcome != 'success'
         with:
           name: cypress-screenshots
           path: cypress/screenshots
 
       - name: Upload failed videos
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: steps.cypress_run.outcome != 'success'
         with:
           name: cypress-videos
           path: cypress/videos
@@ -75,7 +77,7 @@ jobs:
 
       - name: Send Slack notification for a failed signup
         uses: slackapi/slack-github-action@v1.23.0
-        if: failure()
+        if: steps.cypress_run.outcome != 'success'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
@@ -101,3 +103,6 @@ jobs:
                 }
               ]
             }
+      - name: Fail the job on failure of cypress_run
+        if: steps.cypress_run.outcome != 'success'
+        run: exit 1;

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -46,6 +46,11 @@ jobs:
           name: cypress-videos
           path: cypress/videos
 
+      - id: cypress_run_failure_test
+        continue-on-error: true
+        name: Fail on purpose
+        run: exit 1;
+
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -77,7 +82,7 @@ jobs:
 
       - name: Send Slack notification for a failed signup
         uses: slackapi/slack-github-action@v1.23.0
-        if: steps.cypress_run.outcome != 'success'
+        if: steps.cypress_run_failure_test.outcome != 'success'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
@@ -104,5 +109,5 @@ jobs:
               ]
             }
       - name: Fail the job on failure of cypress_run
-        if: steps.cypress_run.outcome != 'success'
+        if: steps.cypress_run_failure_test.outcome != 'success'
         run: exit 1;

--- a/.github/workflows/cypress-smoketest.yml
+++ b/.github/workflows/cypress-smoketest.yml
@@ -46,11 +46,6 @@ jobs:
           name: cypress-videos
           path: cypress/videos
 
-      - id: cypress_run_failure_test
-        continue-on-error: true
-        name: Fail on purpose
-        run: exit 1;
-
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -82,7 +77,7 @@ jobs:
 
       - name: Send Slack notification for a failed signup
         uses: slackapi/slack-github-action@v1.23.0
-        if: steps.cypress_run_failure_test.outcome != 'success'
+        if: steps.cypress_run.outcome != 'success'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
@@ -109,5 +104,5 @@ jobs:
               ]
             }
       - name: Fail the job on failure of cypress_run
-        if: steps.cypress_run_failure_test.outcome != 'success'
+        if: steps.cypress_run.outcome != 'success'
         run: exit 1;


### PR DESCRIPTION
### Description

https://jira.devops.va.gov/browse/API-29516

Now failing tests will not stop the cleanup steps from running leaving lots of orphaned apps in Okta.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
