### PR TITLE
[API-29775] - Block sandbox-access route by LPB property

### DIFF
--- a/cypress/e2e/components/Routes.cy.js
+++ b/cypress/e2e/components/Routes.cy.js
@@ -1,12 +1,8 @@
 /// <reference types="cypress" />
 
-const badUrls = [
-  '/api-publishing/invalid',
-  '/explore/api/invalid',
-  '/explore/api/invalid/docs',
-  '/onboarding/invalid',
-  '/support/invalid',
-];
+const badUrls = ['/api-publishing/invalid', '/onboarding/invalid', '/support/invalid'];
+
+const apiNotFoundUrls = ['/explore/api/invalid', '/explore/api/invalid/docs'];
 
 describe('Routes Wildcard handling', () => {
   beforeEach(() => {
@@ -18,6 +14,16 @@ describe('Routes Wildcard handling', () => {
   badUrls.forEach(item => {
     it(`Should show the 404 page on ${item}`, () => {
       cy.visit(item);
+      cy.get('h1').should('have.text', 'Page not found.');
+    });
+  });
+
+  apiNotFoundUrls.forEach(item => {
+    it(`Should show the 404 page through a thrown error on ${item}`, () => {
+      cy.visit(item);
+      cy.on('uncaught:exception', (err, runnable) => {
+        return false;
+      });
       cy.get('h1').should('have.text', 'Page not found.');
     });
   });

--- a/cypress/fixtures/legacy.json
+++ b/cypress/fixtures/legacy.json
@@ -5,6 +5,7 @@
     "apis": [
       {
         "altID": "appeals",
+        "blockSandboxForm": true,
         "description": "Allows retrieval of all decision review request statuses (both legacy and AMA). Statuses are read only.",
         "docSources": [
           {
@@ -27,6 +28,7 @@
       },
       {
         "altID": "decision_reviews",
+        "blockSandboxForm": true,
         "description": "Allows submission, management, and retrieval of decision review requests and details such as statuses in accordance with the AMA.",
         "docSources": [
           {
@@ -62,6 +64,7 @@
     "apis": [
       {
         "altID": "claims",
+        "blockSandboxForm": false,
         "description": "Submit and track claims",
         "docSources": [
           {
@@ -98,6 +101,7 @@
       },
       {
         "altID": "benefits",
+        "blockSandboxForm": false,
         "description": "Submit PDF claims",
         "docSources": [
           {
@@ -123,6 +127,7 @@
       },
       {
         "altID": "benefitsReferenceData",
+        "blockSandboxForm": false,
         "description": "Look up data and codes for VA benefits claims",
         "docSources": [
           {
@@ -165,6 +170,7 @@
     "apis": [
       {
         "altID": "facilities",
+        "blockSandboxForm": false,
         "description": "VA Facilities",
         "docSources": [
           {
@@ -207,6 +213,7 @@
     "apis": [
       {
         "altID": "vaForms",
+        "blockSandboxForm": false,
         "description": "Look up VA forms and check for new versions.",
         "docSources": [
           {
@@ -249,6 +256,7 @@
     "apis": [
       {
         "altID": "clinicalHealth",
+        "blockSandboxForm": true,
         "description": "Use to develop clinical-facing applications that improve access to and management of patient health data.",
         "docSources": [
           {
@@ -286,6 +294,7 @@
       },
       {
         "altID": "communityCare",
+        "blockSandboxForm": false,
         "description": "VA's Community Care Eligibility API utilizes VA's Facility API, VA's Enrollment \u0026 Eligibility system and others to satisfy requirements found in the VA's MISSION Act of 2018.",
         "docSources": [
           {
@@ -318,6 +327,7 @@
       },
       {
         "altID": "health",
+        "blockSandboxForm": false,
         "description": "Use the OpenID Connect and SMART on FHIR standards to allow Veterans to authorize third-party applications to access data on their behalf.",
         "docSources": [
           {
@@ -387,6 +397,7 @@
       },
       {
         "altID": "providerDirectory",
+        "blockSandboxForm": false,
         "description": "Use this API to return lists of VA providers and their information, such as locations, specialties, office hours, and more.",
         "docSources": [
           {
@@ -408,6 +419,7 @@
       },
       {
         "altID": null,
+        "blockSandboxForm": false,
         "description": "The VA's Health Urgent Care Eligibility API supports industry standards (e.g., Fast Healthcare Interoperability Resources [FHIR]) and provides access to a Veteran's urgent care eligibility status.",
         "docSources": [],
         "enabledByDefault": true,
@@ -444,6 +456,7 @@
     "apis": [
       {
         "altID": "lgyGuarantyRemittance",
+        "blockSandboxForm": false,
         "description": "Lets lenders automate parts of the mortgage post-closing process.",
         "docSources": [
           {
@@ -476,6 +489,7 @@
       },
       {
         "altID": "loan_guaranty",
+        "blockSandboxForm": true,
         "description": "Use the Loan Guaranty API to Manage VA Home Loans.",
         "docSources": [
           {
@@ -511,6 +525,7 @@
     "apis": [
       {
         "altID": "addressValidation",
+        "blockSandboxForm": false,
         "description": "Provides methods to standardize and validate addresses.",
         "docSources": [
           {
@@ -533,6 +548,7 @@
       },
       {
         "altID": "vaLetterGenerator",
+        "blockSandboxForm": false,
         "description": "Generate documents and letters for proof of existing VA benefits and status.",
         "docSources": [
           {
@@ -562,6 +578,7 @@
       },
       {
         "altID": "confirmation",
+        "blockSandboxForm": false,
         "description": "Confirm Veteran status for a given person with an API key.",
         "docSources": [
           {
@@ -583,6 +600,7 @@
       },
       {
         "altID": "verification",
+        "blockSandboxForm": false,
         "description": "Confirm Veteran status for a given person, or get a Veteran’s service history or disability rating.",
         "docSources": [
           {

--- a/cypress/plugins/getRequiredApiSignups.js
+++ b/cypress/plugins/getRequiredApiSignups.js
@@ -28,7 +28,7 @@ export const getRequiredApiSignups = async () => {
       });
       apis
         .filter(api => api.altID)
-        .filter(api => api.vaInternalOnly !== VaInternalOnly.StrictlyInternal)
+        .filter(api => !api.blockSandboxForm)
         .forEach(api => {
           if (api.oAuth) {
             if (api.oAuthTypes.includes('AuthorizationCodeGrant')) {

--- a/public/data/platform-backend/v0/providers/transformations/legacy.json
+++ b/public/data/platform-backend/v0/providers/transformations/legacy.json
@@ -5,6 +5,7 @@
     "apis": [
       {
         "altID": "appeals",
+        "blockSandboxForm": true,
         "description": "Allows retrieval of all decision review request statuses (both legacy and AMA). Statuses are read only.",
         "docSources": [
           {
@@ -27,6 +28,7 @@
       },
       {
         "altID": "decision_reviews",
+        "blockSandboxForm": true,
         "description": "Allows submission, management, and retrieval of decision review requests and details such as statuses in accordance with the AMA.",
         "docSources": [
           {
@@ -62,6 +64,7 @@
     "apis": [
       {
         "altID": "claims",
+        "blockSandboxForm": false,
         "description": "Submit and track claims",
         "docSources": [
           {
@@ -98,6 +101,7 @@
       },
       {
         "altID": "benefits",
+        "blockSandboxForm": false,
         "description": "Submit PDF claims",
         "docSources": [
           {
@@ -123,6 +127,7 @@
       },
       {
         "altID": "benefitsReferenceData",
+        "blockSandboxForm": false,
         "description": "Look up data and codes for VA benefits claims",
         "docSources": [
           {
@@ -165,6 +170,7 @@
     "apis": [
       {
         "altID": "facilities",
+        "blockSandboxForm": false,
         "description": "VA Facilities",
         "docSources": [
           {
@@ -207,6 +213,7 @@
     "apis": [
       {
         "altID": "vaForms",
+        "blockSandboxForm": false,
         "description": "Look up VA forms and check for new versions.",
         "docSources": [
           {
@@ -249,6 +256,7 @@
     "apis": [
       {
         "altID": "clinicalHealth",
+        "blockSandboxForm": true,
         "description": "Use to develop clinical-facing applications that improve access to and management of patient health data.",
         "docSources": [
           {
@@ -286,6 +294,7 @@
       },
       {
         "altID": "communityCare",
+        "blockSandboxForm": false,
         "description": "VA's Community Care Eligibility API utilizes VA's Facility API, VA's Enrollment \u0026 Eligibility system and others to satisfy requirements found in the VA's MISSION Act of 2018.",
         "docSources": [
           {
@@ -318,6 +327,7 @@
       },
       {
         "altID": "health",
+        "blockSandboxForm": false,
         "description": "Use the OpenID Connect and SMART on FHIR standards to allow Veterans to authorize third-party applications to access data on their behalf.",
         "docSources": [
           {
@@ -387,6 +397,7 @@
       },
       {
         "altID": "providerDirectory",
+        "blockSandboxForm": false,
         "description": "Use this API to return lists of VA providers and their information, such as locations, specialties, office hours, and more.",
         "docSources": [
           {
@@ -408,6 +419,7 @@
       },
       {
         "altID": null,
+        "blockSandboxForm": false,
         "description": "The VA's Health Urgent Care Eligibility API supports industry standards (e.g., Fast Healthcare Interoperability Resources [FHIR]) and provides access to a Veteran's urgent care eligibility status.",
         "docSources": [],
         "enabledByDefault": true,
@@ -444,6 +456,7 @@
     "apis": [
       {
         "altID": "lgyGuarantyRemittance",
+        "blockSandboxForm": false,
         "description": "Lets lenders automate parts of the mortgage post-closing process.",
         "docSources": [
           {
@@ -476,6 +489,7 @@
       },
       {
         "altID": "loan_guaranty",
+        "blockSandboxForm": true,
         "description": "Use the Loan Guaranty API to Manage VA Home Loans.",
         "docSources": [
           {
@@ -511,6 +525,7 @@
     "apis": [
       {
         "altID": "addressValidation",
+        "blockSandboxForm": false,
         "description": "Provides methods to standardize and validate addresses.",
         "docSources": [
           {
@@ -533,6 +548,7 @@
       },
       {
         "altID": "vaLetterGenerator",
+        "blockSandboxForm": false,
         "description": "Generate documents and letters for proof of existing VA benefits and status.",
         "docSources": [
           {
@@ -562,6 +578,7 @@
       },
       {
         "altID": "confirmation",
+        "blockSandboxForm": false,
         "description": "Confirm Veteran status for a given person with an API key.",
         "docSources": [
           {
@@ -583,6 +600,7 @@
       },
       {
         "altID": "verification",
+        "blockSandboxForm": false,
         "description": "Confirm Veteran status for a given person, or get a Veteran’s service history or disability rating.",
         "docSources": [
           {

--- a/src/__mocks__/fakeCategories.tsx
+++ b/src/__mocks__/fakeCategories.tsx
@@ -14,6 +14,7 @@ export const fakeCategories: APICategories = {
     apis: [
       {
         altID: null,
+        blockSandboxForm: false,
         categoryUrlFragment: 'lotr',
         categoryUrlSlug: 'lord-of-the-rings',
         description: 'One Ring to rule them all',
@@ -44,6 +45,7 @@ export const fakeCategories: APICategories = {
       },
       {
         altID: null,
+        blockSandboxForm: false,
         categoryUrlFragment: 'lotr',
         categoryUrlSlug: 'lord-of-the-rings',
         deactivationInfo: {
@@ -70,6 +72,7 @@ export const fakeCategories: APICategories = {
       },
       {
         altID: null,
+        blockSandboxForm: false,
         categoryUrlFragment: 'lotr',
         categoryUrlSlug: 'lord-of-the-rings',
         description: 'Hobbits of the Shire',
@@ -102,6 +105,7 @@ export const fakeCategories: APICategories = {
     apis: [
       {
         altID: 'apollo13',
+        blockSandboxForm: false,
         categoryUrlFragment: 'nothing-of-importance',
         categoryUrlSlug: 'importance',
         description: "When a trip to the moon doesn't go according to plan",
@@ -129,6 +133,7 @@ export const fakeCategories: APICategories = {
       },
       {
         altID: 'armageddon',
+        blockSandboxForm: false,
         categoryUrlFragment: 'nothing-of-importance',
         categoryUrlSlug: 'importance',
         description: 'Asteroid Dotty has earth directly in her path, time to call Bruce Willis.',
@@ -157,6 +162,7 @@ export const fakeCategories: APICategories = {
       },
       {
         altID: 'the_martian',
+        blockSandboxForm: false,
         categoryUrlFragment: 'nothing-of-importance',
         categoryUrlSlug: 'importance',
         description:
@@ -192,6 +198,7 @@ export const fakeCategories: APICategories = {
     apis: [
       {
         altID: null,
+        blockSandboxForm: false,
         categoryUrlFragment: 'nothing-of-importance',
         categoryUrlSlug: 'importance',
         description: 'stuff about hoops or whatever',
@@ -212,6 +219,7 @@ export const fakeCategories: APICategories = {
       },
       {
         altID: null,
+        blockSandboxForm: false,
         categoryUrlFragment: 'nothing-of-importance',
         categoryUrlSlug: 'importance',
         description: 'a slow summer game',
@@ -248,6 +256,7 @@ export const fakeAPIs: APIDescription[] = Object.values(fakeCategories).flatMap(
 
 export const extraAPI: APIDescription = {
   altID: null,
+  blockSandboxForm: false,
   categoryUrlFragment: 'nothing-of-importance',
   categoryUrlSlug: 'importance',
   description: 'the beautiful game',

--- a/src/apiDefs/deprecated.test.ts
+++ b/src/apiDefs/deprecated.test.ts
@@ -10,6 +10,7 @@ const urgentCareDeprecationNotice: string = fakeCategories.movies.apis[0].releas
 describe('deprecated API module', () => {
   const apiValues: APIDescription = {
     altID: null,
+    blockSandboxForm: false,
     categoryUrlFragment: 'nothing-of-importance',
     categoryUrlSlug: 'nothing-of-importance',
     description: "it's a fabulous API, you really must try it sometime",

--- a/src/apiDefs/env.test.ts
+++ b/src/apiDefs/env.test.ts
@@ -37,6 +37,7 @@ describe('env module', () => {
     const disabledApiId = 'fake_api';
     const sharedApiValues = {
       altID: null,
+      blockSandboxForm: false,
       categoryUrlFragment: 'nothing-of-importance',
       categoryUrlSlug: 'nothing-of-importance',
       description: "it's a fabulous API, you really must try it sometime",

--- a/src/apiDefs/query.test.ts
+++ b/src/apiDefs/query.test.ts
@@ -37,6 +37,7 @@ import { APIDescription, ProdAccessFormSteps, VaInternalOnly } from './schema';
 
 const rings: APIDescription = {
   altID: null,
+  blockSandboxForm: false,
   categoryUrlFragment: 'lotr',
   categoryUrlSlug: 'lord-of-the-rings',
   description: 'One Ring to rule them all',
@@ -68,6 +69,7 @@ const rings: APIDescription = {
 
 const apollo13: APIDescription = {
   altID: 'apollo13',
+  blockSandboxForm: false,
   categoryUrlFragment: 'movies',
   categoryUrlSlug: 'movies',
   description: "When a trip to the moon doesn't go according to plan",
@@ -96,6 +98,7 @@ const apollo13: APIDescription = {
 
 const theMartian: APIDescription = {
   altID: 'the_martian',
+  blockSandboxForm: false,
   categoryUrlFragment: 'movies',
   categoryUrlSlug: 'movies',
   description:
@@ -119,6 +122,7 @@ const theMartian: APIDescription = {
 
 const basketball: APIDescription = {
   altID: null,
+  blockSandboxForm: false,
   categoryUrlFragment: 'sports',
   categoryUrlSlug: 'sports',
   description: 'stuff about hoops or whatever',

--- a/src/apiDefs/schema.ts
+++ b/src/apiDefs/schema.ts
@@ -69,6 +69,7 @@ export enum ProdAccessFormSteps {
 }
 
 export interface APIDescription {
+  readonly blockSandboxForm: boolean;
   readonly name: string;
   readonly docSources: APIDocSource[];
   readonly urlFragment: string;

--- a/src/containers/documentation/ApiDocumentation.test.tsx
+++ b/src/containers/documentation/ApiDocumentation.test.tsx
@@ -13,6 +13,7 @@ import ApiDocumentation from './ApiDocumentation';
 const ReleaseNotes: string = 'My API&apos;s release notes';
 const api: APIDescription = {
   altID: null,
+  blockSandboxForm: false,
   categoryUrlFragment: 'nothing-of-importance',
   categoryUrlSlug: 'nothing-of-importance',
   description: "it's a great API!",

--- a/src/containers/documentation/ApiOverviewPage.tsx
+++ b/src/containers/documentation/ApiOverviewPage.tsx
@@ -6,7 +6,6 @@ import ReactMarkdown from 'react-markdown';
 import { PageHeader } from '../../components';
 import { ExploreApiTags } from '../../components/exploreApiCard/ExploreApiTags';
 import { APIDescription } from '../../apiDefs/schema';
-import ErrorPage404 from '../ErrorPage404';
 
 import { getApi } from './DocumentationRoot';
 import './ApiOverviewPage.scss';
@@ -25,7 +24,7 @@ const ApiOverviewPage = (): JSX.Element => {
   const api = getApi(params.urlSlug);
 
   if (!api) {
-    return <ErrorPage404 />;
+    throw new Error('API not found');
   }
 
   return (

--- a/src/containers/documentation/ApiPage.test.tsx
+++ b/src/containers/documentation/ApiPage.test.tsx
@@ -8,7 +8,6 @@ import { AppFlags, FlagsProvider, getFlags } from '../../flags';
 import { fakeCategories, unmetDeactivationInfo } from '../../__mocks__/fakeCategories';
 import * as apiDefs from '../../apiDefs/query';
 import store from '../../store';
-// import { apiLoadingState } from '../../types/constants';
 import ApiPage from './ApiPage';
 
 // Convenience variables to try and keep the index values out of the test
@@ -59,9 +58,6 @@ describe('ApiPage', () => {
 
   const lookupApiBySlugMock = jest.spyOn(apiDefs, 'lookupApiBySlug');
   const lookupApiCategoryMock = jest.spyOn(apiDefs, 'lookupApiCategory');
-  // const apisLoadedSpy = jest
-  //   .spyOn(apiDefs, 'getApisLoadedState')
-  //   .mockReturnValue(apiLoadingState.LOADED);
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/containers/documentation/ApiPage.test.tsx
+++ b/src/containers/documentation/ApiPage.test.tsx
@@ -8,7 +8,7 @@ import { AppFlags, FlagsProvider, getFlags } from '../../flags';
 import { fakeCategories, unmetDeactivationInfo } from '../../__mocks__/fakeCategories';
 import * as apiDefs from '../../apiDefs/query';
 import store from '../../store';
-import { apiLoadingState } from '../../types/constants';
+// import { apiLoadingState } from '../../types/constants';
 import ApiPage from './ApiPage';
 
 // Convenience variables to try and keep the index values out of the test
@@ -59,9 +59,9 @@ describe('ApiPage', () => {
 
   const lookupApiBySlugMock = jest.spyOn(apiDefs, 'lookupApiBySlug');
   const lookupApiCategoryMock = jest.spyOn(apiDefs, 'lookupApiCategory');
-  const apisLoadedSpy = jest
-    .spyOn(apiDefs, 'getApisLoadedState')
-    .mockReturnValue(apiLoadingState.LOADED);
+  // const apisLoadedSpy = jest
+  //   .spyOn(apiDefs, 'getApisLoadedState')
+  //   .mockReturnValue(apiLoadingState.LOADED);
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -134,25 +134,23 @@ describe('ApiPage', () => {
   });
 
   describe('given url with api that does not exist', () => {
-    beforeEach(async () => {
+    it("ApiPage throws an error that'll get caught by the ErrorBoundary", () => {
       lookupApiBySlugMock.mockReturnValue(null);
       lookupApiCategoryMock.mockReturnValue(fakeCategories.lotr);
-      await renderApiPage(defaultFlags, '/explore/api/nonexistentapi/docs');
-    });
-
-    it('calls lookupApi methods with correct parameters', () => {
-      expect(lookupApiBySlugMock).toHaveBeenCalledWith('nonexistentapi');
-      expect(lookupApiCategoryMock).toHaveBeenCalledTimes(0);
-    });
-
-    it('renders the api not found page', async () => {
-      apisLoadedSpy.mockReturnValue(apiLoadingState.LOADED);
-      await renderApiPage(
-        defaultFlags,
-        '/explore/api/nonexistantapi/docs',
-        '/explore/api/:urlSlug/docs',
-      );
-      expect(screen.findByText('Try using these links')).not.toBeNull();
+      spyOn(console, 'error');
+      expect(() => {
+        render(
+          <Provider store={store}>
+            <FlagsProvider flags={defaultFlags}>
+              <MemoryRouter initialEntries={['/explore/api/nonexistantapi/docs']}>
+                <Routes>
+                  <Route path="/explore/api/:urlSlug/docs" element={<ApiPage />} />
+                </Routes>
+              </MemoryRouter>
+            </FlagsProvider>
+          </Provider>,
+        );
+      }).toThrow(Error);
     });
   });
 

--- a/src/containers/documentation/ApiPage.tsx
+++ b/src/containers/documentation/ApiPage.tsx
@@ -14,7 +14,6 @@ import { useFlag } from '../../flags';
 
 import { FLAG_API_ENABLED_PROPERTY } from '../../types/constants';
 import ApisLoader from '../../components/apisLoader/ApisLoader';
-import ErrorPage404 from '../ErrorPage404';
 import ApiDocumentation from './ApiDocumentation';
 import ApiNotFoundPage from './ApiNotFoundPage';
 import { getApi } from './DocumentationRoot';
@@ -74,7 +73,7 @@ const ApiPage = (): JSX.Element => {
 
   const api = getApi(params.urlSlug);
   if (!api) {
-    return <ErrorPage404 />;
+    throw new Error('API not found');
   }
   const category = lookupApiCategory(api.categoryUrlFragment ?? '');
   const veteranRedirect = api.veteranRedirect ?? category?.content.veteranRedirect;

--- a/src/containers/documentation/DocumentationRoot.tsx
+++ b/src/containers/documentation/DocumentationRoot.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { getApisLoadedState, lookupApiBySlug } from '../../apiDefs/query';
-import { APIDescription, VaInternalOnly } from '../../apiDefs/schema';
+import { APIDescription } from '../../apiDefs/schema';
 import { ApiAlerts, ApiBreadcrumbs, ContentWithNav, SideNavEntry } from '../../components';
 import { apiLoadingState } from '../../types/constants';
 import ApisLoader from '../../components/apisLoader/ApisLoader';
-import ErrorPage404 from '../ErrorPage404';
 import './Documentation.scss';
 
 interface ExploreSideNavProps {
@@ -38,7 +37,7 @@ const ExploreSideNav = (props: ExploreSideNavProps): JSX.Element => {
         <SideNavEntry end name="Client Credentials Grant" subNavLevel={1} to="client-credentials" />
       )}
       <SideNavEntry end name="Release notes" subNavLevel={1} to="release-notes" />
-      {api.vaInternalOnly !== VaInternalOnly.StrictlyInternal && (
+      {!api.blockSandboxForm && (
         <SideNavEntry end name="Sandbox access" subNavLevel={1} to="sandbox-access" />
       )}
     </>
@@ -56,7 +55,7 @@ const DocumentationRoot = (): JSX.Element => {
     return <ApisLoader />;
   }
   if (!api) {
-    return <ErrorPage404 />;
+    throw new Error('API not found');
   }
 
   return (

--- a/src/containers/documentation/ReleaseNotes.tsx
+++ b/src/containers/documentation/ReleaseNotes.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import ErrorPage404 from '../ErrorPage404';
 import { PageHeader } from '../../components';
 import { getApi } from './DocumentationRoot';
 import './ReleaseNotes.scss';
@@ -11,7 +10,7 @@ export const ReleaseNotes = (): JSX.Element => {
   const params = useParams();
   const api = getApi(params.urlSlug);
   if (!api) {
-    return <ErrorPage404 />;
+    throw new Error('API not found');
   }
 
   return (

--- a/src/containers/documentation/RequestSandboxAccess.tsx
+++ b/src/containers/documentation/RequestSandboxAccess.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from '../../components';
 import { LPB_APPLY_URL } from '../../types/constants';
 import { ApplySuccessResult } from '../../types/forms/apply';
 import { SUPPORT_CONTACT_PATH, TERMS_OF_SERVICE_PATH } from '../../types/constants/paths';
-import ErrorPage404 from '../ErrorPage404';
 import { getApi } from './DocumentationRoot';
 import { SandboxAccessSuccess } from './components/sandbox';
 import './RequestSandboxAccess.scss';
@@ -17,8 +16,8 @@ const RequestSandboxAccess = (): JSX.Element => {
   const api = getApi(urlSlug);
   const [successResults, setSuccessResults] = useState<ApplySuccessResult | false>(false);
 
-  if (!api) {
-    return <ErrorPage404 />;
+  if (!api || api.blockSandboxForm) {
+    throw new Error('API does not allow sandbox signups via the public portal');
   }
 
   const onFormFailure = (data: unknown): void => {


### PR DESCRIPTION
### Description

https://jira.devops.va.gov/browse/API-29775

This will use the `blockSandboxForm` property as the source of truth for whether or not to show the sandbox access form.

Additionally I updated some of the 404 conditionals to use the `throw new Error('API not found')` as a way to limit the number of different places we were calling for the 404 page to have to load in. It will show an error on local but when deployed that error should disappear and users will see the 404 page right away.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
