### PR TITLE
[API-29839] - add additional docs around JWKS "kid" field

### DIFF
--- a/src/components/oauthDocs/ccg/GeneratingJWTContent.tsx
+++ b/src/components/oauthDocs/ccg/GeneratingJWTContent.tsx
@@ -47,6 +47,9 @@ const GeneratingJWTContent: FC<GeneratingJWTProps> = ({ apiName, productionAud, 
       </a>
       .
     </p>
+    <p>
+      Note: Ensure that your CCG assertion includes the optional, but recommended &quot;kid&quot; in the headers section.
+    </p>
     <CodeBlock
       withCopyButton
       language="javascript"
@@ -56,6 +59,7 @@ const GeneratingJWTContent: FC<GeneratingJWTProps> = ({ apiName, productionAud, 
   let secret = fs.readFileSync(key, "utf8");
   const token = jwt.create(claims, secret, algorithm); 
   token.setExpiration(new Date() - getTime() + 60 * 1000);
+  token.setHeader('kid', 'your-key-id-here'); // Recommended
   return token.compact();
 }`}
     />


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->
Original Issue :: [API-29839](https://jira.devops.va.gov/browse/API-29839)
- Adds additional documentation around the JWKS `kid` field on the CCG docs.

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
