### PR TITLE
[Shutdown Prep] - Prep for a locked master branch

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -2,7 +2,7 @@ name: Cypress e2e and Accessibility tests
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, shutdown-master]
     types: [opened, synchronize, reopened, ready_for_review]
 
 env:

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -2,7 +2,7 @@ name: NPM Checks
 
 on:
   pull_request:
-    branches: [master, api-11566/information-architecture]
+    branches: [master, shutdown-master]
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -2,7 +2,7 @@ name: Build Pull Request Deployment Packages
 
 on:
   pull_request:
-    branches: [master, api-11566/information-architecture]
+    branches: [master, shutdown-master]
     types: [opened, synchronize, reopened, ready_for_review]
 
 env:

--- a/.github/workflows/pr-requires-label.yml
+++ b/.github/workflows/pr-requires-label.yml
@@ -1,7 +1,7 @@
 name: Pull Request Labels
 on:
   pull_request:
-    branches: [master]
+    branches: [master, shutdown-master]
     types: [opened, labeled, unlabeled, synchronize]
   workflow_run:
     workflows: ['Automatically label PRs with content changes']


### PR DESCRIPTION
### Description

This change will allow for CI tasks to run mostly unchanged against a new, temporary, `shutdown-master` branch. This is only going to be necessary if there is a government shutdown and merges to the `master` are restricted to just critical updates.