### PR TITLE
[API-30623] - Update PostCSS dependency to fix Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,7 +149,7 @@
         "lodash.noop": "^3.0.1",
         "mini-css-extract-plugin": "^2.7.6",
         "msw": "^1.2.3",
-        "postcss": "^8.4.31",
+        "postcss": ">=8.4.31",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^6.2.1",
         "postcss-normalize": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "lodash.noop": "^3.0.1",
     "mini-css-extract-plugin": "^2.7.6",
     "msw": "^1.2.3",
-    "postcss": "^8.4.31",
+    "postcss": ">=8.4.31",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^6.2.1",
     "postcss-normalize": "^10.0.1",


### PR DESCRIPTION
### Description

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->
Original Issue :: [API-30623](https://jira.devops.va.gov/browse/API-30623)
- Updates the `PostCSS` dependency [as directed by Dependabot](https://github.com/department-of-veterans-affairs/developer-portal/security/dependabot/79).
