### PR TITLE
[API-30849] - Support stealth launched apis

### DIFF
--- a/cypress/fixtures/legacy.json
+++ b/cypress/fixtures/legacy.json
@@ -13,6 +13,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Appeals Status API",
         "openData": false,
@@ -36,6 +37,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Decision Reviews API",
         "openData": false,
@@ -72,6 +74,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Benefits Claims API",
         "openData": false,
@@ -109,6 +112,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Benefits Intake API",
         "openData": false,
@@ -135,6 +139,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "Benefits Reference Data API",
         "openData": true,
@@ -178,6 +183,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "VA Facilities API",
         "openData": true,
@@ -221,6 +227,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "VA Forms API",
         "openData": true,
@@ -264,6 +271,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Clinical Health API (FHIR)",
         "openData": false,
@@ -302,6 +310,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Community Care Eligibility API",
         "openData": false,
@@ -335,6 +344,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Patient Health API (FHIR)",
         "openData": false,
@@ -405,6 +415,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "Provider Directory API",
         "openData": true,
@@ -423,6 +434,7 @@
         "description": "The VA's Health Urgent Care Eligibility API supports industry standards (e.g., Fast Healthcare Interoperability Resources [FHIR]) and provides access to a Veteran's urgent care eligibility status.",
         "docSources": [],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Urgent Care Eligibility API (FHIR)",
         "openData": false,
@@ -464,6 +476,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Guaranty Remittance API",
         "openData": false,
@@ -497,6 +510,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Loan Guaranty API",
         "openData": false,
@@ -533,6 +547,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Address Validation API",
         "openData": false,
@@ -556,6 +571,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "VA Letter Generator API",
         "openData": false,
@@ -586,6 +602,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Veteran Confirmation API",
         "openData": false,
@@ -608,6 +625,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Veteran Verification API",
         "openData": false,

--- a/public/data/platform-backend/v0/providers/transformations/legacy.json
+++ b/public/data/platform-backend/v0/providers/transformations/legacy.json
@@ -13,6 +13,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Appeals Status API",
         "openData": false,
@@ -36,6 +37,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Decision Reviews API",
         "openData": false,
@@ -72,6 +74,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Benefits Claims API",
         "openData": false,
@@ -109,6 +112,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Benefits Intake API",
         "openData": false,
@@ -135,6 +139,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "Benefits Reference Data API",
         "openData": true,
@@ -178,6 +183,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "VA Facilities API",
         "openData": true,
@@ -221,6 +227,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "VA Forms API",
         "openData": true,
@@ -264,6 +271,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Clinical Health API (FHIR)",
         "openData": false,
@@ -302,6 +310,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Community Care Eligibility API",
         "openData": false,
@@ -335,6 +344,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Patient Health API (FHIR)",
         "openData": false,
@@ -405,6 +415,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 2,
         "name": "Provider Directory API",
         "openData": true,
@@ -423,6 +434,7 @@
         "description": "The VA's Health Urgent Care Eligibility API supports industry standards (e.g., Fast Healthcare Interoperability Resources [FHIR]) and provides access to a Veteran's urgent care eligibility status.",
         "docSources": [],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Urgent Care Eligibility API (FHIR)",
         "openData": false,
@@ -464,6 +476,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Guaranty Remittance API",
         "openData": false,
@@ -497,6 +510,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Loan Guaranty API",
         "openData": false,
@@ -533,6 +547,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "Address Validation API",
         "openData": false,
@@ -556,6 +571,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 3,
         "name": "VA Letter Generator API",
         "openData": false,
@@ -586,6 +602,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Veteran Confirmation API",
         "openData": false,
@@ -608,6 +625,7 @@
           }
         ],
         "enabledByDefault": true,
+        "isStealthLaunched": false,
         "lastProdAccessStep": 4,
         "name": "Veteran Verification API",
         "openData": false,

--- a/src/__mocks__/fakeCategories.tsx
+++ b/src/__mocks__/fakeCategories.tsx
@@ -20,6 +20,7 @@ export const fakeCategories: APICategories = {
         description: 'One Ring to rule them all',
         docSources: [], // doesn't matter yet
         enabledByDefault: true,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Four,
         name: 'Rings API',
         oAuth: false,
@@ -57,6 +58,7 @@ export const fakeCategories: APICategories = {
         description: 'Three pretty gems',
         docSources: [],
         enabledByDefault: true,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Three,
         name: 'Silmarils API',
         oAuth: false,
@@ -78,6 +80,7 @@ export const fakeCategories: APICategories = {
         description: 'Hobbits of the Shire',
         docSources: [], // doesn't matter here
         enabledByDefault: true,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Two,
         name: 'Hobbits API',
         oAuth: false,
@@ -111,6 +114,7 @@ export const fakeCategories: APICategories = {
         description: "When a trip to the moon doesn't go according to plan",
         docSources: [], // doesn't matter here
         enabledByDefault: true,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Three,
         name: 'Apollo 13 API',
         oAuth: true,
@@ -139,6 +143,7 @@ export const fakeCategories: APICategories = {
         description: 'Asteroid Dotty has earth directly in her path, time to call Bruce Willis.',
         docSources: [], // doesn't matter here
         enabledByDefault: true,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Three,
         name: 'Armageddon API',
         oAuth: true,
@@ -169,6 +174,7 @@ export const fakeCategories: APICategories = {
           'Mark Watney (played by Matt Damon) is stranded on Mars forced to survive alone for over a year.',
         docSources: [], // doesn't matter here
         enabledByDefault: true,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Four,
         name: 'The Martian API',
         oAuth: false,
@@ -204,6 +210,7 @@ export const fakeCategories: APICategories = {
         description: 'stuff about hoops or whatever',
         docSources: [], // doesn't matter here
         enabledByDefault: true,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Three,
         name: 'Basketball API',
         oAuth: false,
@@ -225,6 +232,7 @@ export const fakeCategories: APICategories = {
         description: 'a slow summer game',
         docSources: [], // doesn't matter here
         enabledByDefault: false,
+        isStealthLaunched: false,
         lastProdAccessStep: ProdAccessFormSteps.Three,
         name: 'Baseball API',
         oAuth: false,
@@ -262,6 +270,7 @@ export const extraAPI: APIDescription = {
   description: 'the beautiful game',
   docSources: [],
   enabledByDefault: true,
+  isStealthLaunched: false,
   lastProdAccessStep: ProdAccessFormSteps.Four,
   name: 'Soccer API',
   oAuth: false,

--- a/src/apiDefs/deprecated.test.ts
+++ b/src/apiDefs/deprecated.test.ts
@@ -16,6 +16,7 @@ describe('deprecated API module', () => {
     description: "it's a fabulous API, you really must try it sometime",
     docSources: [],
     enabledByDefault: true,
+    isStealthLaunched: false,
     lastProdAccessStep: ProdAccessFormSteps.Three,
     name: 'My API',
     oAuth: false,

--- a/src/apiDefs/env.test.ts
+++ b/src/apiDefs/env.test.ts
@@ -42,6 +42,7 @@ describe('env module', () => {
       categoryUrlSlug: 'nothing-of-importance',
       description: "it's a fabulous API, you really must try it sometime",
       docSources: [],
+      isStealthLaunched: false,
       lastProdAccessStep: ProdAccessFormSteps.Four,
       name: 'My API',
       oAuth: false,

--- a/src/apiDefs/env.ts
+++ b/src/apiDefs/env.ts
@@ -11,7 +11,7 @@ export const isHostedApiEnabled = (apiIdentifier: string, defaultValue: boolean)
 };
 
 export const getEnvFlags = (): { [apiId: string]: boolean } => {
-  const allApis: APIDescription[] = getAllApis();
+  const allApis: APIDescription[] = getAllApis(true);
   const envFlags = allApis.reduce((result: { [key: string]: boolean }, api: APIDescription) => {
     result[api.urlFragment] = isHostedApiEnabled(api.urlFragment, api.enabledByDefault);
     return result;

--- a/src/apiDefs/query.test.ts
+++ b/src/apiDefs/query.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /**
  * This file contains unit tests for the query.ts module in this directory. Because query.ts
  * is the only module that accesses data from the Typescript definition files in data/ directly,
@@ -22,7 +23,6 @@ import { fakeCategories } from '../__mocks__/fakeCategories';
 import {
   apisFor,
   countActiveApisByCategory,
-  getAllQuickstartCategorySlugs,
   getApiCategoryOrder,
   includesOAuthAPI,
   lookupApiByFragment,
@@ -32,6 +32,7 @@ import {
   includesInternalOnlyAPI,
   onlyOpenDataAPIs,
   includesOpenDataAPI,
+  getAllApis,
 } from './query';
 import { APIDescription, ProdAccessFormSteps, VaInternalOnly } from './schema';
 
@@ -147,7 +148,9 @@ const basketball: APIDescription = {
 };
 
 describe('query module', () => {
-  store.dispatch(setApis(fakeCategories));
+  beforeEach(() => {
+    store.dispatch(setApis(fakeCategories));
+  });
 
   describe('lookupApiByFragment', () => {
     it('finds the API if it is defined', () => {
@@ -247,12 +250,6 @@ describe('query module', () => {
     });
   });
 
-  describe('getAllQuickstartCategorySlugs', () => {
-    it('returns the list of all API category slugs that have a quickstart page', () => {
-      expect(getAllQuickstartCategorySlugs()).toStrictEqual(['movies']);
-    });
-  });
-
   describe('apisFor', () => {
     it('retrieves the requested APIs', () => {
       const apis = apisFor(['the_martian', 'basketball']);
@@ -289,6 +286,39 @@ describe('query module', () => {
   describe('countActiveApisByCategory', () => {
     it('returns number of active apis for a given category', () => {
       expect(countActiveApisByCategory('lotr')).toEqual(2);
+    });
+  });
+});
+describe('cover conditions that interact with stealth launched APIs', () => {
+  beforeEach(() => {
+    const tempCategories = fakeCategories;
+    tempCategories.sports.apis[0] = {
+      ...tempCategories.sports.apis[0],
+      isStealthLaunched: true,
+    };
+    store.dispatch(setApis(tempCategories));
+  });
+  describe('getAllApis with stealth launched APIs', () => {
+    it('getAllApis skips APIs that are stealth launched by default', () => {
+      const apis = getAllApis();
+      expect(apis).toHaveLength(7);
+    });
+
+    it('getAllApis includes APIs that are stealth launched when requested', () => {
+      const apis = getAllApis(true);
+      expect(apis).toHaveLength(8);
+    });
+  });
+  describe('lookupApiBySlug with isStealthLaunched true', () => {
+    it('finds the API by its slug even while stealth launched', () => {
+      const api = lookupApiBySlug('basketball');
+      expect(api).toEqual({ ...basketball, isStealthLaunched: true });
+    });
+  });
+  describe('lookupApiByFragment with isStealthLaunched true', () => {
+    it('finds the API by its fragment even while stealth launched', () => {
+      const api = lookupApiByFragment('basketball');
+      expect(api).toEqual({ ...basketball, isStealthLaunched: true });
     });
   });
 });

--- a/src/apiDefs/query.test.ts
+++ b/src/apiDefs/query.test.ts
@@ -43,6 +43,7 @@ const rings: APIDescription = {
   description: 'One Ring to rule them all',
   docSources: [], // doesn't matter yet
   enabledByDefault: true,
+  isStealthLaunched: false,
   lastProdAccessStep: ProdAccessFormSteps.Four,
   name: 'Rings API',
   oAuth: false,
@@ -75,6 +76,7 @@ const apollo13: APIDescription = {
   description: "When a trip to the moon doesn't go according to plan",
   docSources: [],
   enabledByDefault: true,
+  isStealthLaunched: false,
   lastProdAccessStep: ProdAccessFormSteps.Three,
   name: 'Apollo 13 API',
   oAuth: true,
@@ -105,6 +107,7 @@ const theMartian: APIDescription = {
     'Mark Watney (played by Matt Damon) is stranded on Mars forced to survive alone for over a year.',
   docSources: [], // doesn't matter here
   enabledByDefault: true,
+  isStealthLaunched: false,
   lastProdAccessStep: ProdAccessFormSteps.Four,
   name: 'The Martian API',
   oAuth: false,
@@ -128,6 +131,7 @@ const basketball: APIDescription = {
   description: 'stuff about hoops or whatever',
   docSources: [], // doesn't matter here
   enabledByDefault: true,
+  isStealthLaunched: false,
   lastProdAccessStep: ProdAccessFormSteps.Three,
   name: 'Basketball API',
   oAuth: false,

--- a/src/apiDefs/query.ts
+++ b/src/apiDefs/query.ts
@@ -68,10 +68,11 @@ const getApiCategoryOrder = (): string[] => {
   });
 };
 
-const getAllApis = (): APIDescription[] =>
+const getAllApis = (includeStealth: boolean = false): APIDescription[] =>
   Object.values(rootGetApiDefinitions.getApiDefinitions())
     .flatMap((category: APICategory) => category.apis)
-    .sort((a, b) => (a.name > b.name ? 1 : -1));
+    .sort((a, b) => (a.name > b.name ? 1 : -1))
+    .filter((api: APIDescription) => !api.isStealthLaunched || includeStealth);
 const getActiveApis = (): APIDescription[] =>
   getAllApis().filter(
     (api: APIDescription) =>
@@ -113,13 +114,13 @@ const getAllQuickstartCategorySlugs = (): string[] =>
 
 const lookupApiBySlug = (urlSlug: string): APIDescription | null => {
   const hasMatchingIdentifier = (apiDesc: APIDescription): boolean => apiDesc.urlSlug === urlSlug;
-  const apiResult = getAllApis().find(hasMatchingIdentifier);
+  const apiResult = getAllApis(true).find(hasMatchingIdentifier);
   return apiResult ?? null;
 };
 const lookupApiByFragment = (apiKey: string): APIDescription | null => {
   const hasMatchingIdentifier = (apiDesc: APIDescription): boolean =>
     apiDesc.urlFragment === apiKey;
-  const apiResult = getAllApis().find(hasMatchingIdentifier);
+  const apiResult = getAllApis(true).find(hasMatchingIdentifier);
   return apiResult ?? null;
 };
 

--- a/src/apiDefs/query.ts
+++ b/src/apiDefs/query.ts
@@ -107,11 +107,6 @@ const getActiveCCGApis = (): APIDescription[] =>
 const getAllKeyAuthApis = (): APIDescription[] =>
   getAllApis().filter((item: APIDescription) => !item.oAuth);
 
-const getAllQuickstartCategorySlugs = (): string[] =>
-  Object.entries(rootGetApiDefinitions.getApiDefinitions())
-    .filter((item: [string, APICategory]) => !!item[1].content.quickstart)
-    .map((item: [string, APICategory]) => item[0]);
-
 const lookupApiBySlug = (urlSlug: string): APIDescription | null => {
   const hasMatchingIdentifier = (apiDesc: APIDescription): boolean => apiDesc.urlSlug === urlSlug;
   const apiResult = getAllApis(true).find(hasMatchingIdentifier);
@@ -185,7 +180,6 @@ export {
   getActiveAuthCodeApis,
   getAllCCGApis,
   getActiveCCGApis,
-  getAllQuickstartCategorySlugs,
   getApiCategoryOrder,
   getApiDefinitions,
   lookupApiByFragment,

--- a/src/apiDefs/schema.ts
+++ b/src/apiDefs/schema.ts
@@ -70,6 +70,7 @@ export enum ProdAccessFormSteps {
 
 export interface APIDescription {
   readonly blockSandboxForm: boolean;
+  readonly isStealthLaunched: boolean;
   readonly name: string;
   readonly docSources: APIDocSource[];
   readonly urlFragment: string;

--- a/src/components/oauthDocs/acg/ScopesContent.test.tsx
+++ b/src/components/oauthDocs/acg/ScopesContent.test.tsx
@@ -19,6 +19,7 @@ const renderComponentWithScopes = (scopes: string[]): void => {
         },
       ],
       enabledByDefault: true,
+      isStealthLaunched: false,
       lastProdAccessStep: 4,
       name: 'Default API',
       oAuth: true,

--- a/src/containers/documentation/ApiDocumentation.test.tsx
+++ b/src/containers/documentation/ApiDocumentation.test.tsx
@@ -23,6 +23,7 @@ const api: APIDescription = {
     },
   ],
   enabledByDefault: true,
+  isStealthLaunched: false,
   lastProdAccessStep: ProdAccessFormSteps.Three,
   name: 'My API',
   oAuth: false,


### PR DESCRIPTION
### Description
https://jira.devops.va.gov/browse/API-30849

This adds a filter into the root `getAllApis()` method to allow stealth launched APIs to be ignored in all cases except when viewed directly by their URL. This is conditioned based on an `isStealthLaunched` property on the APIDescription object.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
