### PR TITLE
[API-30849] - Remove Flag around SwaggerDocs

### DIFF
--- a/src/containers/documentation/ApiDocumentation.tsx
+++ b/src/containers/documentation/ApiDocumentation.tsx
@@ -3,8 +3,6 @@ import { useDispatch } from 'react-redux';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import * as actions from '../../actions';
 import { APIDescription, ApiDescriptionPropType } from '../../apiDefs/schema';
-import { Flag } from '../../flags';
-import { FLAG_HOSTED_APIS } from '../../types/constants';
 import { SwaggerDocs } from './SwaggerDocs';
 
 import '../../../node_modules/react-tabs/style/react-tabs.scss';
@@ -38,11 +36,7 @@ const ApiDocumentation = (props: ApiDocumentationProps): JSX.Element => {
   /*
    * RENDER
    */
-  return (
-    <Flag name={[FLAG_HOSTED_APIS, urlFragment]}>
-      <SwaggerDocs docSource={docSources[0]} apiName={urlFragment} />
-    </Flag>
-  );
+  return <SwaggerDocs docSource={docSources[0]} apiName={urlFragment} />;
 };
 
 ApiDocumentation.propTypes = ApiDocumentationPropTypes;


### PR DESCRIPTION
### Description

https://jira.devops.va.gov/browse/API-30849

Removes this check because it's blocking specifically the swagger docs on a stealth launched API from being viewable on the portal.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
