### PR TITLE
[API-34671] - Conditionally disable test users page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8669,9 +8669,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001519",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+      "version": "1.0.30001594",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
+      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
       "funding": [
         {
           "type": "opencollective",
@@ -8685,8 +8685,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",

--- a/src/apiDefs/schema.ts
+++ b/src/apiDefs/schema.ts
@@ -102,6 +102,7 @@ export interface OAuthInfo {
 
 export interface ACGInfo {
   readonly baseAuthPath: string;
+  readonly disableTestUsersPage?: boolean;
   readonly sandboxAud: string;
   readonly productionAud: string;
   readonly scopes: string[];

--- a/src/containers/documentation/DocumentationRoot.tsx
+++ b/src/containers/documentation/DocumentationRoot.tsx
@@ -42,7 +42,7 @@ const ExploreSideNav = (props: ExploreSideNavProps): JSX.Element => {
             subNavLevel={1}
             to="authorization-code"
           />
-          {!!userId && testUserHash && (
+          {!api.oAuthInfo?.acgInfo?.disableTestUsersPage && !!userId && testUserHash && (
             <SideNavEntry
               end
               name="Test users"

--- a/src/containers/documentation/TestUsersPage.test.tsx
+++ b/src/containers/documentation/TestUsersPage.test.tsx
@@ -100,8 +100,6 @@ describe('TestUsersPage disabled', () => {
   describe('Static Content', () => {
     it('renders the page header after the progress bar completes', () => {
       lookupApiByFragmentMock.mockReturnValue(armageddonApi);
-      // await waitFor(() => cleanup());
-      // try {
       spyOn(console, 'error');
       expect(() => {
         render(

--- a/src/containers/documentation/TestUsersPage.test.tsx
+++ b/src/containers/documentation/TestUsersPage.test.tsx
@@ -9,6 +9,7 @@ import { FlagsProvider, getFlags } from '../../flags';
 import store from '../../store';
 import * as apiDefs from '../../apiDefs/query';
 import testUserData from '../../../cypress/fixtures/test-user-data.json';
+import { ACGInfo, APIDescription } from '../../apiDefs/schema';
 import TestUsersPage from './TestUsersPage';
 
 const server = setupServer(
@@ -78,6 +79,46 @@ describe('TestUsersPage', () => {
         const user5 = screen.queryByText(/Pauline/); // First name
         expect(user5).toBeInTheDocument();
       });
+    });
+  });
+});
+describe('TestUsersPage disabled', () => {
+  const armageddonApi: APIDescription = {
+    ...fakeCategories.movies.apis[1],
+    oAuthInfo: {
+      ...fakeCategories.movies.apis[1].oAuthInfo,
+      acgInfo: {
+        ...fakeCategories.movies.apis[1].oAuthInfo?.acgInfo,
+        disableTestUsersPage: true,
+      } as ACGInfo,
+    },
+  };
+  const lookupApiByFragmentMock = jest.spyOn(apiDefs, 'lookupApiBySlug');
+
+  beforeAll(() => server.listen());
+
+  describe('Static Content', () => {
+    it('renders the page header after the progress bar completes', () => {
+      lookupApiByFragmentMock.mockReturnValue(armageddonApi);
+      // await waitFor(() => cleanup());
+      // try {
+      spyOn(console, 'error');
+      expect(() => {
+        render(
+          <Provider store={store}>
+            <FlagsProvider flags={getFlags()}>
+              <MemoryRouter initialEntries={['/explore/api/armageddon/test-users/123/good-hash']}>
+                <Routes>
+                  <Route
+                    path="/explore/api/:urlSlug/test-users/:userId/:hash"
+                    element={<TestUsersPage />}
+                  />
+                </Routes>
+              </MemoryRouter>
+            </FlagsProvider>
+          </Provider>,
+        );
+      }).toThrow();
     });
   });
 });

--- a/src/containers/documentation/TestUsersPage.tsx
+++ b/src/containers/documentation/TestUsersPage.tsx
@@ -60,6 +60,9 @@ const TestUsersPage = (): JSX.Element => {
   if (!api) {
     throw new Error('API not found');
   }
+  if (api.oAuthInfo?.acgInfo?.disableTestUsersPage) {
+    throw new Error('Test users page disabled for this API');
+  }
 
   if (testUserAccess === testUserAccessState.INIT) {
     return <LoadingIndicator label="Loading" message="Validating access to Test User Data." />;


### PR DESCRIPTION
### Description

https://jira.devops.va.gov/browse/API-34671

Specifically requested for the Clinical Health API but built to be configurable, this will allow us to add `disableTestUsersPage: true` to the `acgInfo` property within LPB to disable an API's Test Users page when they have ACG OAuth available.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
