### PR TITLE
Update PR label workflow run trigger

### DIFF
--- a/.github/workflows/pr-requires-label.yml
+++ b/.github/workflows/pr-requires-label.yml
@@ -2,7 +2,7 @@ name: Pull Request Labels
 on:
   pull_request:
     branches: [master, shutdown-master]
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, labeled, unlabeled, synchronize, reopened, ready_for_review]
   workflow_run:
     workflows: ['Automatically label PRs with content changes']
     types:


### PR DESCRIPTION
### Description

Small workflow update to resolve issue where visual regressions would not re-trigger this CI test.

<!--
What is your PR doing and why? Please link a ticket and any other relevant
relations like Slack threads or Sentry issues.
-->

### Requested feedback

<!-- Is there any specific feedback you are looking for on the PR? It's okay if this is blank. -->
